### PR TITLE
Eliminate use of StringIO in the arguments tests

### DIFF
--- a/tests/tools/assigner/test_arguments.py
+++ b/tests/tools/assigner/test_arguments.py
@@ -30,14 +30,8 @@ class ArgumentTests(unittest.TestCase):
 
     def test_get_arguments_none(self):
         sys.argv = ['kafka-assigner']
-<<<<<<< HEAD
         with capture_sys_output() as (stdout, stderr):
             self.assertRaises(SystemExit, set_up_arguments, {}, {}, [self.null_plugin])
-=======
-        with self.assertRaises(SystemExit):
-            with redirect_err_output():
-                set_up_arguments({}, {}, [self.null_plugin])
->>>>>>> c2c5c7c27057298d61d5cad927321aea132b7eae
 
     def test_get_modules(self):
         self.create_action_map()

--- a/tests/tools/assigner/test_arguments.py
+++ b/tests/tools/assigner/test_arguments.py
@@ -30,7 +30,7 @@ class ArgumentTests(unittest.TestCase):
 
     def test_get_arguments_none(self):
         sys.argv = ['kafka-assigner']
-        with capture_sys_output() as (stdout, stderr):
+        with redirect_err_output():
             self.assertRaises(SystemExit, set_up_arguments, {}, {}, [self.null_plugin])
 
     def test_get_modules(self):


### PR DESCRIPTION
Missed this when merging in everything and getting it clean. We don't really need StringIO in the tests for arguments.