### PR TITLE
Fix even balance module

### DIFF
--- a/kafka/tools/assigner/actions/balancemodules/count.py
+++ b/kafka/tools/assigner/actions/balancemodules/count.py
@@ -37,7 +37,8 @@ class ActionBalanceCount(ActionBalanceModule):
         # Calculate partition counts for each position first
         max_count = {}
         for pos in range(max_pos):
-            # Calculate the maximum number of partitions each broker should have (floor(average) + 1)
+            # Calculate the maximum number of partitions each broker should have (floor(average))
+            # We'll also track a remainder and make sure they only go 1 per broker
             pcount = 0
             for broker in self.cluster.brokers:
                 if pos in self.cluster.brokers[broker].partitions:

--- a/kafka/tools/assigner/actions/balancemodules/even.py
+++ b/kafka/tools/assigner/actions/balancemodules/even.py
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 from kafka.tools.assigner import log
 from kafka.tools.assigner.actions import ActionBalanceModule
 

--- a/kafka/tools/assigner/actions/balancemodules/even.py
+++ b/kafka/tools/assigner/actions/balancemodules/even.py
@@ -1,72 +1,64 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-
 from kafka.tools.assigner import log
 from kafka.tools.assigner.actions import ActionBalanceModule
+
+
+def pmap_matches_target(pmap, target):
+    for pos in pmap:
+        for broker_id in pos:
+            if pos[broker_id] != target:
+                return False
+    return True
 
 
 class ActionBalanceEven(ActionBalanceModule):
     name = "even"
     helpstr = "Evenly spread topics that are a multiple of the number of brokers across the cluster"
 
-    def process_cluster(self):
-        for topic in self.cluster.topics:
-            if len(self.cluster.topics[topic].partitions) % len(self.cluster.brokers) != 0:
+    def check_topic_ok(self, topic):
+            if len(topic.partitions) % len(self.cluster.brokers) != 0:
                 log.warn("Skipping topic {0} as it has {1} partitions, which is not a multiple of the number of brokers ({2})".format(
-                    topic, len(self.cluster.topics[topic].partitions), len(self.cluster.brokers)))
-                continue
-            rf = len(self.cluster.topics[topic].partitions[0].replicas)
-            target = len(self.cluster.topics[topic].partitions) / len(self.cluster.brokers)
+                    topic.name, len(topic.partitions), len(self.cluster.brokers)))
+                return False
+            if any([len(partition.replicas) != len(topic.partitions[0].replicas) for partition in topic.partitions]):
+                log.warn("Skipping topic {0} as not all partitions have the same replication factor".format(topic.name))
+                return False
+            return True
 
-            different_rf = False
-            for partition in self.cluster.topics[topic].partitions:
-                if len(partition.replicas) != rf:
-                    log.warn("Skipping topic {0} as not all partitions have the same replication factor".format(topic))
-                    different_rf = True
-            if different_rf:
+    def process_cluster(self):
+        for topic_name in self.cluster.topics:
+            topic = self.cluster.topics[topic_name]
+            if not self.check_topic_ok(topic):
                 continue
+            target = len(topic.partitions) / len(self.cluster.brokers)
 
             # Initialize broker map for this topic.
-            pmap = [dict.fromkeys(self.cluster.brokers.keys(), 0) for pos in range(rf)]
-            for partition in self.cluster.topics[topic].partitions:
+            pmap = [dict.fromkeys(self.cluster.brokers.keys(), 0) for pos in range(len(topic.partitions[0].replicas))]
+            for partition in topic.partitions:
                 for i, replica in enumerate(partition.replicas):
                     pmap[i][replica.id] += 1
 
-            for partition in self.cluster.topics[topic].partitions:
-                for pos in range(rf):
-                    # Current placement is fine. Leave the replica where it is
-                    if pmap[pos][partition.replicas[pos].id] <= target:
-                        continue
-
-                    # Find a new replica for the partition at this position
-                    for bid in pmap[pos]:
-                        if pmap[pos][bid] >= target:
+            while not pmap_matches_target(pmap, target):
+                for partition in topic.partitions:
+                    for pos in range(len(partition.replicas)):
+                        # Current placement is fine (or low). Leave the replica where it is
+                        if pmap[pos][partition.replicas[pos].id] <= target:
                             continue
-                        broker = self.cluster.brokers[bid]
-                        source = partition.replicas[pos]
 
-                        if broker in partition.replicas:
-                            other_pos = partition.replicas.index(broker)
-                            partition.swap_replica_positions(source, broker)
-                            pmap[other_pos][broker.id] -= 1
-                            pmap[other_pos][source.id] += 1
-                        else:
-                            partition.swap_replicas(source, broker)
+                        # Find a new replica for the partition at this position
+                        for bid in pmap[pos]:
+                            if pmap[pos][bid] >= target:
+                                continue
+                            broker = self.cluster.brokers[bid]
+                            source = partition.replicas[pos]
 
-                        pmap[pos][broker.id] += 1
-                        pmap[pos][source.id] -= 1
-                        break
+                            if broker in partition.replicas:
+                                other_pos = partition.replicas.index(broker)
+                                partition.swap_replica_positions(source, broker)
+                                pmap[other_pos][broker.id] -= 1
+                                pmap[other_pos][source.id] += 1
+                            else:
+                                partition.swap_replicas(source, broker)
+
+                            pmap[pos][broker.id] += 1
+                            pmap[pos][source.id] -= 1
+                            break

--- a/tests/tools/assigner/actions/balancemodules/test_even.py
+++ b/tests/tools/assigner/actions/balancemodules/test_even.py
@@ -2,11 +2,11 @@ import sys
 import unittest
 
 from argparse import Namespace
-from ..fixtures import set_up_cluster, set_up_subparser
+from ..fixtures import set_up_cluster, set_up_subparser, set_up_cluster_4broker
 
 from kafka.tools.assigner.models.topic import Topic
 from kafka.tools.assigner.actions.balance import ActionBalance
-from kafka.tools.assigner.actions.balancemodules.even import ActionBalanceEven
+from kafka.tools.assigner.actions.balancemodules.even import ActionBalanceEven, pmap_matches_target
 
 
 class ActionBalanceEvenTests(unittest.TestCase):
@@ -14,6 +14,23 @@ class ActionBalanceEvenTests(unittest.TestCase):
         self.cluster = set_up_cluster()
         (self.parser, self.subparsers) = set_up_subparser()
         self.args = Namespace()
+
+    def is_cluster_even(self, skip_topics=[]):
+        for topic_name in self.cluster.topics:
+            topic = self.cluster.topics[topic_name]
+            if topic_name in skip_topics:
+                continue
+
+            # Create broker map for this topic.
+            pmap = [dict.fromkeys(self.cluster.brokers.keys(), 0) for pos in range(len(topic.partitions[0].replicas))]
+            for partition in topic.partitions:
+                for i, replica in enumerate(partition.replicas):
+                    pmap[i][replica.id] += 1
+
+            if not pmap_matches_target(pmap, len(topic.partitions) / len(self.cluster.brokers)):
+                print("Position map for topic {0}: {1}".format(topic_name, pmap))
+                return False
+        return True
 
     def test_configure_args(self):
         ActionBalance.configure_args(self.subparsers)
@@ -43,11 +60,7 @@ class ActionBalanceEvenTests(unittest.TestCase):
 
         action = ActionBalanceEven(self.args, self.cluster)
         action.process_cluster()
-
-        assert self.cluster.topics['testTopic1'].partitions[0].replicas == [b1, b2]
-        assert self.cluster.topics['testTopic1'].partitions[1].replicas == [b2, b1]
-        assert self.cluster.topics['testTopic2'].partitions[0].replicas == [b2, b1]
-        assert self.cluster.topics['testTopic2'].partitions[1].replicas == [b1, b2]
+        assert self.is_cluster_even()
 
     def test_process_cluster_odd_count(self):
         b1 = self.cluster.brokers[1]
@@ -66,14 +79,7 @@ class ActionBalanceEvenTests(unittest.TestCase):
 
         action = ActionBalanceEven(self.args, self.cluster)
         action.process_cluster()
-
-        assert self.cluster.topics['testTopic1'].partitions[0].replicas == [b1, b2]
-        assert self.cluster.topics['testTopic1'].partitions[1].replicas == [b2, b1]
-        assert self.cluster.topics['testTopic2'].partitions[0].replicas == [b2, b1]
-        assert self.cluster.topics['testTopic2'].partitions[1].replicas == [b1, b2]
-        assert self.cluster.topics['testTopic3'].partitions[0].replicas == [b1, b2]
-        assert self.cluster.topics['testTopic3'].partitions[1].replicas == [b1, b2]
-        assert self.cluster.topics['testTopic3'].partitions[2].replicas == [b1, b2]
+        assert self.is_cluster_even(skip_topics=['testTopic3'])
 
     def test_process_cluster_different_rf(self):
         b1 = self.cluster.brokers[1]
@@ -88,10 +94,55 @@ class ActionBalanceEvenTests(unittest.TestCase):
 
         action = ActionBalanceEven(self.args, self.cluster)
         action.process_cluster()
+        assert self.is_cluster_even(skip_topics=['testTopic3'])
 
-        assert self.cluster.topics['testTopic1'].partitions[0].replicas == [b1, b2]
-        assert self.cluster.topics['testTopic1'].partitions[1].replicas == [b2, b1]
-        assert self.cluster.topics['testTopic2'].partitions[0].replicas == [b2, b1]
-        assert self.cluster.topics['testTopic2'].partitions[1].replicas == [b1, b2]
-        assert self.cluster.topics['testTopic3'].partitions[0].replicas == [b1, b2]
-        assert self.cluster.topics['testTopic3'].partitions[1].replicas == [b1]
+    def test_skip_topic_ok(self):
+        action = ActionBalanceEven(self.args, self.cluster)
+        assert action.check_topic_ok(self.cluster.topics['testTopic1'])
+
+    def test_skip_topic_different_rf(self):
+        b1 = self.cluster.brokers[1]
+        b2 = self.cluster.brokers[2]
+        self.cluster.add_topic(Topic("testTopic3", 2))
+        partition = self.cluster.topics['testTopic3'].partitions[0]
+        partition.add_replica(b1, 0)
+        partition.add_replica(b2, 1)
+        partition = self.cluster.topics['testTopic3'].partitions[1]
+        partition.add_replica(b1, 0)
+
+        action = ActionBalanceEven(self.args, self.cluster)
+        assert not action.check_topic_ok(self.cluster.topics['testTopic3'])
+
+    def test_skip_topic_odd_count(self):
+        b1 = self.cluster.brokers[1]
+        b2 = self.cluster.brokers[2]
+        self.cluster.add_topic(Topic("testTopic3", 3))
+        partition = self.cluster.topics['testTopic3'].partitions[0]
+        partition.add_replica(b1, 0)
+        partition.add_replica(b2, 1)
+        partition = self.cluster.topics['testTopic3'].partitions[1]
+        partition.add_replica(b1, 0)
+        partition.add_replica(b2, 1)
+        partition = self.cluster.topics['testTopic3'].partitions[2]
+        partition.add_replica(b1, 0)
+        partition.add_replica(b2, 1)
+
+        action = ActionBalanceEven(self.args, self.cluster)
+        assert not action.check_topic_ok(self.cluster.topics['testTopic3'])
+
+    def test_pmap_matches_target(self):
+        target = 2
+        pmap = [{1: 2, 2: 2, 3: 2, 4: 2}, {1: 2, 2: 2, 3: 2, 4: 2}]
+        assert pmap_matches_target(pmap, target)
+
+    def test_pmap_matches_target_fails(self):
+        target = 1
+        pmap = [{1: 1, 2: 2, 3: 0, 4: 1}, {1: 1, 2: 1, 3: 2, 4: 0}]
+        assert not pmap_matches_target(pmap, target)
+
+    def test_process_cluster_4broker(self):
+        self.cluster = set_up_cluster_4broker()
+
+        action = ActionBalanceEven(self.args, self.cluster)
+        action.process_cluster()
+        assert self.is_cluster_even(skip_topics=['testTopic3'])

--- a/tests/tools/assigner/actions/fixtures.py
+++ b/tests/tools/assigner/actions/fixtures.py
@@ -26,6 +26,54 @@ def set_up_cluster():
     return cluster
 
 
+def set_up_cluster_4broker():
+    cluster = Cluster()
+    cluster.add_broker(Broker(1, "brokerhost1.example.com"))
+    cluster.add_broker(Broker(2, "brokerhost2.example.com"))
+    cluster.add_broker(Broker(3, "brokerhost3.example.com"))
+    cluster.add_broker(Broker(4, "brokerhost4.example.com"))
+    cluster.add_topic(Topic("testTopic1", 4))
+    cluster.add_topic(Topic("testTopic2", 4))
+    cluster.add_topic(Topic("testTopic3", 4))
+    partition = cluster.topics['testTopic1'].partitions[0]
+    partition.add_replica(cluster.brokers[1], 0)
+    partition.add_replica(cluster.brokers[2], 1)
+    partition = cluster.topics['testTopic1'].partitions[1]
+    partition.add_replica(cluster.brokers[2], 0)
+    partition.add_replica(cluster.brokers[3], 1)
+    partition = cluster.topics['testTopic1'].partitions[2]
+    partition.add_replica(cluster.brokers[2], 0)
+    partition.add_replica(cluster.brokers[3], 1)
+    partition = cluster.topics['testTopic1'].partitions[3]
+    partition.add_replica(cluster.brokers[4], 0)
+    partition.add_replica(cluster.brokers[1], 1)
+    partition = cluster.topics['testTopic2'].partitions[0]
+    partition.add_replica(cluster.brokers[4], 0)
+    partition.add_replica(cluster.brokers[3], 1)
+    partition = cluster.topics['testTopic2'].partitions[1]
+    partition.add_replica(cluster.brokers[2], 0)
+    partition.add_replica(cluster.brokers[4], 1)
+    partition = cluster.topics['testTopic2'].partitions[2]
+    partition.add_replica(cluster.brokers[2], 0)
+    partition.add_replica(cluster.brokers[1], 1)
+    partition = cluster.topics['testTopic2'].partitions[3]
+    partition.add_replica(cluster.brokers[3], 0)
+    partition.add_replica(cluster.brokers[1], 1)
+    partition = cluster.topics['testTopic3'].partitions[0]
+    partition.add_replica(cluster.brokers[3], 0)
+    partition.add_replica(cluster.brokers[2], 1)
+    partition = cluster.topics['testTopic3'].partitions[1]
+    partition.add_replica(cluster.brokers[4], 0)
+    partition.add_replica(cluster.brokers[2], 1)
+    partition = cluster.topics['testTopic3'].partitions[2]
+    partition.add_replica(cluster.brokers[1], 0)
+    partition.add_replica(cluster.brokers[2], 1)
+    partition = cluster.topics['testTopic3'].partitions[3]
+    partition.add_replica(cluster.brokers[3], 0)
+    partition.add_replica(cluster.brokers[4], 1)
+    return cluster
+
+
 def set_up_subparser():
     aparser = argparse.ArgumentParser(prog='kafka-assigner', description='Rejigger Kafka cluster partitions')
     subparsers = aparser.add_subparsers(help='Select manipulation module to use')


### PR DESCRIPTION
Primarily, this PR fixes the `even` balance module. I found it had a tendency to pick the wrong partition to change for a topic, and making another pass will correct the problem. Added a test that cover a specific case where this happens, and changed the asserts for the other tests to always make sure the balance is correct.

This also contains some changes to the main tests to increase coverage there.