### PR TITLE
Create rack aware balance module

### DIFF
--- a/kafka/tools/assigner/actions/balancemodules/rackaware.py
+++ b/kafka/tools/assigner/actions/balancemodules/rackaware.py
@@ -32,7 +32,7 @@ class ActionBalanceRackAware(ActionBalanceModule):
         super(ActionBalanceRackAware, self).__init__(args, cluster)
 
         # Set up a random ordered deque of brokers to use when we can't swap
-        broker_list = self.cluster.brokers.values()
+        broker_list = list(self.cluster.brokers.values())
         random.shuffle(broker_list)
         self._random_brokers = deque(broker_list)
 

--- a/kafka/tools/assigner/actions/balancemodules/rackaware.py
+++ b/kafka/tools/assigner/actions/balancemodules/rackaware.py
@@ -1,0 +1,177 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import random
+from collections import deque
+from operator import attrgetter
+
+from kafka.tools.assigner import log
+from kafka.tools.assigner.actions import ActionBalanceModule
+from kafka.tools.assigner.exceptions import BalanceException
+
+
+class ActionBalanceRackAware(ActionBalanceModule):
+    name = "rackaware"
+    helpstr = "Reassign partition replicas to assure they are in different racks, attempting to maintain counts and size per-broker"
+
+    def __init__(self, args, cluster):
+        super(ActionBalanceRackAware, self).__init__(args, cluster)
+
+        # Set up a random ordered deque of brokers to use when we can't swap
+        broker_list = self.cluster.brokers.values()
+        random.shuffle(broker_list)
+        self._random_brokers = deque(broker_list)
+
+    def process_cluster(self):
+        log.info("Starting partition balance by rack")
+
+        # Check if rack information is set for the cluster
+        broker_racks = [broker.rack for broker in self.cluster.brokers.values()]
+        if len(set(broker_racks)) == 1:
+            raise BalanceException("Cannot balance cluster by rack as it has no rack information")
+
+        # Figure out the max RF for the cluster
+        max_rf = self.cluster.max_replication_factor()
+
+        # Balance partitions at each position separately
+        for pos in range(max_rf):
+            self._process_partitions_at_pos(pos)
+
+    def _get_sorted_partition_list_at_pos(self, pos):
+        # Create a list of partitions to use at this position, sorted by size
+        partitions = [p for p in self.cluster.partitions() if (len(p.replicas) > (pos + 1))]
+        partitions.sort(key=attrgetter('size'))
+        return partitions
+
+    def _process_partitions_at_pos(self, pos):
+        # Create a sorted list of partitions to use at this position (descending size)
+        partitions = self._get_sorted_partition_list_at_pos(pos)
+
+        for i, partition in enumerate(partitions):
+            # Check if the partition is already on different racks
+            partition_racks = racks_for_replica_list(partition.replicas)
+            if len(partition_racks) == len(set(partition_racks)):
+                continue
+
+            # Find the partition that is closest in size that has a replica that can be swapped
+            # We slice the partitions list here, leaving off the partition we're working on. This way we can just pop off the lists
+            large_partitions = partitions[min(i+1, len(partitions)):]
+            large_partitions.reverse()
+            swap_partition = self._try_pick_swap_partition(partition, pos, partitions[0:i], large_partitions)
+
+            if swap_partition is not None:
+                # Swap the replicas at the current position on both partitions
+                orig_replica = partition.replicas[pos]
+                partition.swap_replicas(orig_replica, swap_partition.replicas[pos])
+                swap_partition.swap_replicas(swap_partition.replicas[pos], orig_replica)
+            else:
+                # If we don't have a swap, pick the next broker in a different rack
+                swap_broker = self._try_pick_new_broker(partition, pos)
+                partition.swap_replicas(partition.replicas[pos], swap_broker)
+
+    def _try_pick_swap_partition(self, partition, pos, small_partitions, large_partitions):
+        """
+        Given a partition and a replica position, try and find a partition that has a replica in the same position
+        that can be swapped to improve rack separation. The partition selected should be the closest in size possible.
+
+        :params partiton: the Partition with the replica that needs to be changed
+        :params pos: the position of the replica to be changed
+        :params small_partitions: a list of Partition objects, sorted in order by size, smaller than the Partion to change
+        :params large_partitions: a list of Partition objects, sorted in order by size, larger than the Partion to change
+        :returns: a Partition object that is OK to swap, or None
+        """
+        while len(small_partitions) + len(large_partitions) > 0:
+            smaller_size_diff = difference_in_size_to_last_partition(partition, small_partitions)
+            larger_size_diff = difference_in_size_to_last_partition(partition, large_partitions)
+
+            # Check the partition with the smallest size difference
+            target = None
+            if larger_size_diff < smaller_size_diff:
+                target = large_partitions.pop()
+            else:
+                target = small_partitions.pop()
+            if check_partition_swappable(partition.replicas, target.replicas, pos):
+                return target
+
+        return None
+
+    def _try_pick_new_broker(self, partition, pos):
+        """
+        Given a partition and a replica position, pick a new broker for that position that is in a different rack than other replicas
+
+        :params partition: the Partition to modify
+        :params pos: the replica position to change
+        :returns: the Broker to swap in at the specified position
+        :raises: BalanceException if a broker cannot be found that is in a different rack
+        """
+        replica_racks = set(racks_for_replica_list(partition.replicas, pos))
+        for bidx in range(len(self._random_brokers)):
+            broker = self._random_brokers.popleft()
+            self._random_brokers.append(broker)
+            if broker in partition.replicas:
+                continue
+            if broker.rack not in replica_racks:
+                return broker
+
+        raise BalanceException("Cannot find a swap for broker {0} on partition {1}:{2} at position {3}".format(partition.replicas[pos].id,
+                                                                                                               partition.topic.name,
+                                                                                                               partition.num,
+                                                                                                               pos))
+
+
+def difference_in_size_to_last_partition(partition, partitions):
+    """
+    Return the difference in size between the specified Partition and the last Partition in the provided list. If the list is
+    empty, return infinity.
+
+    :params partition: a Partition object to use for calculating the difference
+    :params partitions: a list of Partition objects
+    :returns: The difference in size between partition and the last Partition in the partitions list, or infinity
+    """
+    if len(partitions) == 0:
+        return float("inf")
+    return abs(partition.size - partitions[-1].size)
+
+
+def racks_for_replica_list(replicas, pos=None):
+    """
+    Returns a set of racks for each of the given replicas in the list
+    Skip the replica at position pos, if specified
+
+    :params replicas: a list of Broker objects
+    :params pos: a replica position to skip, or None to not skip a replica
+    :returns: a list of racks
+    """
+    return [replica.rack for i, replica in enumerate(replicas) if (pos is None) or (i != pos)]
+
+
+def check_partition_swappable(replicas_a, replicas_b, pos):
+    """
+    Check if the broker at position pos in the first replica list can be swapped with the replica at position pos in the second list
+    1. replicas_a[pos] must not be in the replicas_b list
+    2. replicas_b[pos] must not be in the replicas_a list
+    3. replicas_a[pos] must have a different rack than the replicas in replicas_b (except for replicas_b[pos])
+    4. replicas_b[pos] must have a different rack than the replicas in replicas_a (except for replicas_a[pos])
+
+    :params replicas_a: the first replica list
+    :params replicas_b: the second replica list
+    :params pos: the position in the replica list to be replaced
+    :returns: True if the broker can be swapped into this replica list, False otherwise
+    """
+    if replicas_a[pos] in replicas_b or replicas_b[pos] in replicas_a:
+        return False
+    return replicas_a[pos].rack not in racks_for_replica_list(replicas_b, pos) and replicas_b[pos].rack not in racks_for_replica_list(replicas_a, pos)

--- a/kafka/tools/assigner/exceptions.py
+++ b/kafka/tools/assigner/exceptions.py
@@ -58,3 +58,7 @@ class ReassignmentFailedException(AssignerException):
 
 class UnknownBrokerException(AssignerException):
     errstr = "There is an unknown broker hostname"
+
+
+class BalanceException(AssignerException):
+    errstr = "The balance module failed to satisfy the requirements"

--- a/kafka/tools/assigner/models/__init__.py
+++ b/kafka/tools/assigner/models/__init__.py
@@ -5,3 +5,6 @@ class BaseModel(object):
         if not isinstance(other, self.__class__):
             raise TypeError
         return not any([getattr(self, attr_name) != getattr(other, attr_name) for attr_name in self.equality_attrs])
+
+    def __hash__(self):
+        return id(self)

--- a/kafka/tools/assigner/models/broker.py
+++ b/kafka/tools/assigner/models/broker.py
@@ -31,6 +31,7 @@ class Broker(BaseModel):
         self.hostname = hostname
         self.jmx_port = -1
         self.port = None
+        self.rack = None
         self.version = None
         self.endpoints = None
         self.timestamp = None
@@ -48,14 +49,11 @@ class Broker(BaseModel):
             raise ConfigurationException("Cannot parse broker data in zookeeper. This version of Kafka may not be supported.")
 
         # These things are optional, and are pulled in for convenience or extra features
-        try:
-            newbroker.jmx_port = data['jmx_port']
-            newbroker.port = data['port']
-            newbroker.version = data['version']
-            newbroker.endpoints = data['endpoints']
-            newbroker.timestamp = data['timestamp']
-        except KeyError:
-            pass
+        for attr in ['jmx_port', 'port', 'rack', 'version', 'endpoints', 'timestamp']:
+            try:
+                setattr(newbroker, attr, data[attr])
+            except KeyError:
+                pass
 
         return newbroker
 
@@ -64,6 +62,7 @@ class Broker(BaseModel):
         newbroker = Broker(self.id, self.hostname)
         newbroker.jmx_port = self.jmx_port
         newbroker.port = self.port
+        newbroker.rack = self.rack
         newbroker.version = self.version
         newbroker.endpoints = self.endpoints
         newbroker.timestamp = self.timestamp

--- a/tests/tools/assigner/actions/balancemodules/test_rackaware.py
+++ b/tests/tools/assigner/actions/balancemodules/test_rackaware.py
@@ -1,0 +1,273 @@
+import sys
+import unittest
+
+from argparse import Namespace
+from collections import deque
+from mock import call, patch
+from ..fixtures import set_up_cluster, set_up_subparser
+
+from kafka.tools.assigner.exceptions import BalanceException
+from kafka.tools.assigner.models.broker import Broker
+from kafka.tools.assigner.actions.balance import ActionBalance
+from kafka.tools.assigner.actions.balancemodules.rackaware import (ActionBalanceRackAware, check_partition_swappable, racks_for_replica_list,
+                                                                   difference_in_size_to_last_partition)
+
+
+class ActionBalanceRackAwareTests(unittest.TestCase):
+    def setUp(self):
+        self.cluster = set_up_cluster()
+        self.cluster.topics['testTopic1'].partitions[0].size = 1000
+        self.cluster.topics['testTopic1'].partitions[1].size = 1000
+        self.cluster.topics['testTopic2'].partitions[0].size = 2000
+        self.cluster.topics['testTopic2'].partitions[1].size = 2000
+
+        (self.parser, self.subparsers) = set_up_subparser()
+        self.args = Namespace()
+
+    def test_configure_args(self):
+        ActionBalance.configure_args(self.subparsers)
+        sys.argv = ['kafka-assigner', 'balance', '-t', 'rackaware']
+        parsed_args = self.parser.parse_args()
+        assert parsed_args.action == 'balance'
+
+    def test_init_broker_deque(self):
+        action = ActionBalanceRackAware(self.args, self.cluster)
+        assert set(action._random_brokers) == set(self.cluster.brokers.values())
+
+    def test_check_partition_swappable_already_exists(self):
+        b1 = self.cluster.brokers[1]
+        b2 = self.cluster.brokers[2]
+        replicas_a = [b1, b2]
+        replicas_b = [b2, b1]
+        assert check_partition_swappable(replicas_a, replicas_b, 0) is False
+        assert check_partition_swappable(replicas_b, replicas_a, 0) is False
+
+    def test_check_partition_swappable_racks_collide(self):
+        b1 = self.cluster.brokers[1]
+        b2 = self.cluster.brokers[2]
+        b3 = Broker(3, 'brokerhost3.example.com')
+        b4 = Broker(4, 'brokerhost4.example.com')
+        b2.rack = "a"
+        b3.rack = "a"
+        b4.rack = "b"
+        replicas_a = [b1, b2]
+        replicas_b = [b3, b4]
+        assert check_partition_swappable(replicas_a, replicas_b, 0) is False
+        assert check_partition_swappable(replicas_b, replicas_a, 0) is False
+
+    def test_check_partition_swappable_racks_ok(self):
+        b1 = self.cluster.brokers[1]
+        b2 = self.cluster.brokers[2]
+        b3 = Broker(1, 'brokerhost3.example.com')
+        b4 = Broker(1, 'brokerhost4.example.com')
+        b2.rack = "a"
+        b3.rack = "b"
+        b4.rack = "b"
+        replicas_a = [b1, b2]
+        replicas_b = [b3, b4]
+        assert check_partition_swappable(replicas_a, replicas_b, 0) is True
+        assert check_partition_swappable(replicas_b, replicas_a, 0) is True
+
+    def test_racks_for_replica_list_nopos(self):
+        b1 = self.cluster.brokers[1]
+        b2 = self.cluster.brokers[2]
+        assert racks_for_replica_list([b1, b2]) == ["a", "b"]
+
+    def test_racks_for_replica_list_pos(self):
+        b1 = self.cluster.brokers[1]
+        b2 = self.cluster.brokers[2]
+        assert racks_for_replica_list([b1, b2], 1) == ["a"]
+
+    def test_difference_in_size_larger(self):
+        partitions = [self.cluster.topics['testTopic1'].partitions[0],
+                      self.cluster.topics['testTopic1'].partitions[1]]
+        partitions[0].size = 1000
+        partitions[1].size = 2000
+        p = self.cluster.topics['testTopic2'].partitions[0]
+        p.size = 3000
+        assert difference_in_size_to_last_partition(p, partitions) == 1000
+
+    def test_difference_in_size_smaller(self):
+        partitions = [self.cluster.topics['testTopic1'].partitions[0],
+                      self.cluster.topics['testTopic1'].partitions[1]]
+        partitions[0].size = 1000
+        partitions[1].size = 2000
+        p = self.cluster.topics['testTopic2'].partitions[0]
+        p.size = 1000
+        assert difference_in_size_to_last_partition(p, partitions) == 1000
+
+    def test_difference_in_size_empty_list(self):
+        partitions = []
+        p = self.cluster.topics['testTopic2'].partitions[0]
+        p.size = 1000
+        assert difference_in_size_to_last_partition(p, partitions) == float("inf")
+
+    def test_try_pick_new_broker_skipself(self):
+        b1 = self.cluster.brokers[1]
+        b2 = self.cluster.brokers[2]
+        b3 = Broker(3, 'brokerhost3.example.com')
+        self.cluster.add_broker(b3)
+        b3.rack = "a"
+        action = ActionBalanceRackAware(self.args, self.cluster)
+
+        # Firmly order the deque
+        action._random_brokers = deque([b1, b2, b3])
+        newbroker = action._try_pick_new_broker(self.cluster.topics['testTopic1'].partitions[0], 0)
+        assert newbroker == b3
+        assert action._random_brokers == deque([b1, b2, b3])
+
+    def test_try_pick_new_broker_failed(self):
+        action = ActionBalanceRackAware(self.args, self.cluster)
+        self.assertRaises(BalanceException, action._try_pick_new_broker, self.cluster.topics['testTopic1'].partitions[0], 0)
+
+    def test_try_pick_new_broker(self):
+        b1 = self.cluster.brokers[1]
+        b2 = self.cluster.brokers[2]
+        b3 = Broker(3, 'brokerhost3.example.com')
+        self.cluster.add_broker(b3)
+        b3.rack = "b"
+        action = ActionBalanceRackAware(self.args, self.cluster)
+
+        # Firmly order the deque
+        action._random_brokers = deque([b3, b1, b2])
+        newbroker = action._try_pick_new_broker(self.cluster.topics['testTopic1'].partitions[0], 1)
+        assert newbroker == b3
+        assert action._random_brokers == deque([b1, b2, b3])
+
+    def test_try_pick_swap_partition_none(self):
+        action = ActionBalanceRackAware(self.args, self.cluster)
+        small_partitions = [self.cluster.topics['testTopic1'].partitions[0],
+                            self.cluster.topics['testTopic1'].partitions[1]]
+        large_partitions = [self.cluster.topics['testTopic2'].partitions[0]]
+        p = self.cluster.topics['testTopic2'].partitions[1]
+        small_partitions[0].size = 1000
+        small_partitions[1].size = 2000
+        large_partitions[0].size = 4000
+        p.size = 3000
+        assert action._try_pick_swap_partition(p, 0, small_partitions, large_partitions) is None
+
+    @patch('kafka.tools.assigner.actions.balancemodules.rackaware.check_partition_swappable')
+    def test_try_pick_swap_partitions_nosmall(self, mock_check):
+        action = ActionBalanceRackAware(self.args, self.cluster)
+        small_partitions = []
+        large_partitions = [self.cluster.topics['testTopic2'].partitions[0]]
+        p = self.cluster.topics['testTopic2'].partitions[1]
+        large_partitions[0].size = 4000
+        p.size = 3000
+
+        mock_check.return_value = True
+        assert action._try_pick_swap_partition(p, 0, small_partitions, large_partitions) == self.cluster.topics['testTopic2'].partitions[0]
+
+    @patch('kafka.tools.assigner.actions.balancemodules.rackaware.check_partition_swappable')
+    def test_try_pick_swap_partitions_nolarge(self, mock_check):
+        action = ActionBalanceRackAware(self.args, self.cluster)
+        large_partitions = []
+        small_partitions = [self.cluster.topics['testTopic2'].partitions[0]]
+        p = self.cluster.topics['testTopic2'].partitions[1]
+        small_partitions[0].size = 1000
+        p.size = 3000
+
+        mock_check.return_value = True
+        assert action._try_pick_swap_partition(p, 0, small_partitions, large_partitions) == self.cluster.topics['testTopic2'].partitions[0]
+
+    @patch('kafka.tools.assigner.actions.balancemodules.rackaware.check_partition_swappable')
+    def test_try_pick_swap_partition_full(self, mock_check):
+        action = ActionBalanceRackAware(self.args, self.cluster)
+        small_partitions = [self.cluster.topics['testTopic1'].partitions[0],
+                            self.cluster.topics['testTopic1'].partitions[1]]
+        large_partitions = [self.cluster.topics['testTopic2'].partitions[0]]
+        p = self.cluster.topics['testTopic2'].partitions[1]
+        small_partitions[0].size = 1000
+        small_partitions[1].size = 2000
+        large_partitions[0].size = 4000
+        p.size = 3000
+
+        mock_check.side_effect = [False, False, True]
+        target = action._try_pick_swap_partition(p, 0, small_partitions, large_partitions)
+
+        b1 = self.cluster.brokers[1]
+        b2 = self.cluster.brokers[2]
+        mock_check.assert_has_calls([call([b1, b2], [b2, b1], 0), call([b1, b2], [b2, b1], 0), call([b1, b2], [b1, b2], 0)])
+        assert target == self.cluster.topics['testTopic1'].partitions[0]
+
+    def test_get_sorted_list(self):
+        action = ActionBalanceRackAware(self.args, self.cluster)
+        p1 = self.cluster.topics['testTopic1'].partitions[0]
+        p2 = self.cluster.topics['testTopic1'].partitions[1]
+        p3 = self.cluster.topics['testTopic2'].partitions[0]
+        p4 = self.cluster.topics['testTopic2'].partitions[1]
+        p1.size = 1000
+        p2.size = 6000
+        p3.size = 3000
+        p4.size = 4000
+        assert action._get_sorted_partition_list_at_pos(0) == [p1, p3, p4, p2]
+
+    def test_get_sorted_list_missing_replica(self):
+        action = ActionBalanceRackAware(self.args, self.cluster)
+        p1 = self.cluster.topics['testTopic1'].partitions[0]
+        p2 = self.cluster.topics['testTopic1'].partitions[1]
+        p3 = self.cluster.topics['testTopic2'].partitions[0]
+        p4 = self.cluster.topics['testTopic2'].partitions[1]
+        p1.size = 1000
+        p2.size = 6000
+        p3.size = 3000
+        p4.size = 4000
+        p1.replicas = [self.cluster.brokers[1]]
+        assert action._get_sorted_partition_list_at_pos(0) == [p3, p4, p2]
+
+    @patch.object(ActionBalanceRackAware, '_try_pick_swap_partition')
+    def test_process_partitions_at_pos_nochange(self, mock_pick):
+        action = ActionBalanceRackAware(self.args, self.cluster)
+        action._process_partitions_at_pos(0)
+        mock_pick.assert_not_called()
+
+    @patch.object(ActionBalanceRackAware, '_try_pick_swap_partition')
+    def test_process_partitions_at_pos_swap_partition(self, mock_pick):
+        action = ActionBalanceRackAware(self.args, self.cluster)
+        b1 = self.cluster.brokers[1]
+        b2 = self.cluster.brokers[2]
+        b3 = Broker(3, 'brokerhost3.example.com')
+        b4 = Broker(4, 'brokerhost4.example.com')
+        self.cluster.add_broker(b3)
+        self.cluster.add_broker(b4)
+        b3.rack = "a"
+        b4.rack = "c"
+        self.cluster.topics['testTopic2'].partitions[0].swap_replicas(b2, b3)
+        self.cluster.topics['testTopic1'].partitions[1].swap_replicas(b1, b4)
+        mock_pick.return_value = self.cluster.topics['testTopic1'].partitions[1]
+
+        action._process_partitions_at_pos(0)
+        assert self.cluster.topics['testTopic1'].partitions[1].replicas == [b3, b4]
+        assert self.cluster.topics['testTopic2'].partitions[0].replicas == [b2, b1]
+
+    @patch.object(ActionBalanceRackAware, '_try_pick_swap_partition')
+    @patch.object(ActionBalanceRackAware, '_try_pick_new_broker')
+    def test_process_partitions_at_pos_swap_broker(self, mock_broker, mock_pick):
+        action = ActionBalanceRackAware(self.args, self.cluster)
+        b1 = self.cluster.brokers[1]
+        b2 = self.cluster.brokers[2]
+        b3 = Broker(3, 'brokerhost3.example.com')
+        b4 = Broker(4, 'brokerhost4.example.com')
+        self.cluster.add_broker(b3)
+        self.cluster.add_broker(b4)
+        b3.rack = "a"
+        b4.rack = "c"
+        self.cluster.topics['testTopic2'].partitions[0].swap_replicas(b2, b3)
+        self.cluster.topics['testTopic1'].partitions[1].swap_replicas(b1, b4)
+        mock_pick.return_value = None
+        mock_broker.return_value = b2
+
+        action._process_partitions_at_pos(0)
+        assert self.cluster.topics['testTopic1'].partitions[1].replicas == [b2, b4]
+        assert self.cluster.topics['testTopic2'].partitions[0].replicas == [b2, b1]
+
+    def test_process_cluster_single_rack(self):
+        action = ActionBalanceRackAware(self.args, self.cluster)
+        self.cluster.brokers[2].rack = "a"
+        self.assertRaises(BalanceException, action.process_cluster)
+
+    @patch.object(ActionBalanceRackAware, '_process_partitions_at_pos')
+    def test_process_cluster(self, mock_process):
+        action = ActionBalanceRackAware(self.args, self.cluster)
+        action.process_cluster()
+        mock_process.assert_has_calls([call(0), call(1)])

--- a/tests/tools/assigner/actions/fixtures.py
+++ b/tests/tools/assigner/actions/fixtures.py
@@ -9,6 +9,8 @@ def set_up_cluster():
     cluster = Cluster()
     cluster.add_broker(Broker(1, "brokerhost1.example.com"))
     cluster.add_broker(Broker(2, "brokerhost2.example.com"))
+    cluster.brokers[1].rack = "a"
+    cluster.brokers[2].rack = "b"
     cluster.add_topic(Topic("testTopic1", 2))
     cluster.add_topic(Topic("testTopic2", 2))
     partition = cluster.topics['testTopic1'].partitions[0]
@@ -32,6 +34,10 @@ def set_up_cluster_4broker():
     cluster.add_broker(Broker(2, "brokerhost2.example.com"))
     cluster.add_broker(Broker(3, "brokerhost3.example.com"))
     cluster.add_broker(Broker(4, "brokerhost4.example.com"))
+    cluster.brokers[1].rack = "a"
+    cluster.brokers[2].rack = "a"
+    cluster.brokers[3].rack = "b"
+    cluster.brokers[4].rack = "b"
     cluster.add_topic(Topic("testTopic1", 4))
     cluster.add_topic(Topic("testTopic2", 4))
     cluster.add_topic(Topic("testTopic3", 4))

--- a/tests/tools/assigner/test_exceptions.py
+++ b/tests/tools/assigner/test_exceptions.py
@@ -41,6 +41,10 @@ class ExceptionTests(unittest.TestCase):
         e = kafka.tools.assigner.exceptions.ReassignmentFailedException()
         assert isinstance(e, kafka.tools.assigner.exceptions.AssignerException)
 
+    def test_exception_balance(self):
+        e = kafka.tools.assigner.exceptions.BalanceException()
+        assert isinstance(e, kafka.tools.assigner.exceptions.AssignerException)
+
     def test_exception_unknown_broker(self):
         e = kafka.tools.assigner.exceptions.UnknownBrokerException()
         assert isinstance(e, kafka.tools.assigner.exceptions.AssignerException)


### PR DESCRIPTION
This PR adds a new balance module named "rackaware". It will adjust replica assignments to try and assure that every partition has each of its replicas on different racks. It does this while attempting to maintain the count of number of partitions per broker, as well as the size per broker, by swapping partitions that are close in size as much as possible.

This module relies on the rack attribute of the brokers as provided by Kafka 0.10. If you try and use it on an older version that does not support the rack attribute it will throw an exception and stop the balance process.