### PR TITLE
Add exclude-topics argument

### DIFF
--- a/kafka/tools/assigner/__main__.py
+++ b/kafka/tools/assigner/__main__.py
@@ -136,7 +136,7 @@ def main():
     run_plugins_at_step(plugins, 'before_ple')
 
     if not args.skip_ple:
-        all_cluster_partitions = [p for p in action_to_run.cluster.partitions()]
+        all_cluster_partitions = [p for p in action_to_run.cluster.partitions(args.exclude_topics)]
         batches = split_partitions_into_batches(all_cluster_partitions, batch_size=args.ple_size, use_class=ReplicaElection)
         log.info("Number of replica elections: {0}".format(len(batches)))
         run_preferred_replica_elections(batches, args, tools_path, plugins, dry_run)

--- a/kafka/tools/assigner/actions/balancemodules/count.py
+++ b/kafka/tools/assigner/actions/balancemodules/count.py
@@ -74,6 +74,11 @@ class ActionBalanceCount(ActionBalanceModule):
                             # If we have moved enough partitions from this broker, exit out of the inner loop
                             if (source.num_partitions_at_position(pos) < max_count[pos][0]) or (diff == 0):
                                 break
+
+                            # Skip topics that are being excluded
+                            if partition.topic.name in self.args.exclude_topics:
+                                continue
+
                             # If the partition is already on the target, swap positions only if it makes the balance better
                             if broker in partition.replicas:
                                 other_pos = partition.replicas.index(broker)

--- a/kafka/tools/assigner/actions/balancemodules/even.py
+++ b/kafka/tools/assigner/actions/balancemodules/even.py
@@ -32,6 +32,9 @@ class ActionBalanceEven(ActionBalanceModule):
     helpstr = "Evenly spread topics that are a multiple of the number of brokers across the cluster"
 
     def check_topic_ok(self, topic):
+            if topic.name in self.args.exclude_topics:
+                log.warn("Skipping topic {0} as it is explicitly excluded".format(topic.name))
+                return False
             if len(topic.partitions) % len(self.cluster.brokers) != 0:
                 log.warn("Skipping topic {0} as it has {1} partitions, which is not a multiple of the number of brokers ({2})".format(
                     topic.name, len(topic.partitions), len(self.cluster.brokers)))

--- a/kafka/tools/assigner/actions/balancemodules/rackaware.py
+++ b/kafka/tools/assigner/actions/balancemodules/rackaware.py
@@ -53,7 +53,7 @@ class ActionBalanceRackAware(ActionBalanceModule):
 
     def _get_sorted_partition_list_at_pos(self, pos):
         # Create a list of partitions to use at this position, sorted by size
-        partitions = [p for p in self.cluster.partitions() if (len(p.replicas) > (pos + 1))]
+        partitions = [p for p in self.cluster.partitions(self.args.exclude_topics) if (len(p.replicas) > (pos + 1))]
         partitions.sort(key=attrgetter('size'))
         return partitions
 

--- a/kafka/tools/assigner/actions/balancemodules/size.py
+++ b/kafka/tools/assigner/actions/balancemodules/size.py
@@ -43,7 +43,7 @@ class ActionBalanceSize(ActionBalanceModule):
 
             # Create a sorted list of partitions to use at this position (descending size)
             # Throw out partitions that are 4K or less in size, as they are effectively empty
-            partitions[pos] = [p for p in self.cluster.partitions() if (len(p.replicas) > pos) and (p.size > 4)]
+            partitions[pos] = [p for p in self.cluster.partitions(self.args.exclude_topics) if (len(p.replicas) > pos) and (p.size > 4)]
             partitions[pos].sort(key=attrgetter('size'), reverse=True)
 
             # Calculate broker size at this position

--- a/kafka/tools/assigner/actions/clone.py
+++ b/kafka/tools/assigner/actions/clone.py
@@ -41,7 +41,7 @@ class ActionClone(ActionModule):
 
     def process_cluster(self):
         source_set = set(self.sources)
-        for partition in self.cluster.partitions():
+        for partition in self.cluster.partitions(self.args.exclude_topics):
             if len(source_set & set([replica.id for replica in partition.replicas])) > 0:
                 if self.to_broker in partition.replicas:
                     log.warn("Target broker (ID {0}) is already in the replica list for {1}:{2}".format(self.to_broker.id, partition.topic.name, partition.num))

--- a/kafka/tools/assigner/actions/remove.py
+++ b/kafka/tools/assigner/actions/remove.py
@@ -55,7 +55,6 @@ class ActionRemove(ActionModule):
                 iterlist = list(broker.partitions[position])
                 for partition in iterlist:
                     if partition.topic.name in self.args.exclude_topics:
-                        log.debug("Skipping partition {0}-{1} due to exclude-topics".format(partition.topic.name, partition.num))
                         continue
 
                     # Find a new replica for this partition

--- a/kafka/tools/assigner/actions/remove.py
+++ b/kafka/tools/assigner/actions/remove.py
@@ -16,7 +16,6 @@
 # under the License.
 
 from collections import deque
-from kafka.tools.assigner import log
 from kafka.tools.assigner.actions import ActionModule
 from kafka.tools.assigner.exceptions import ConfigurationException, NotEnoughReplicasException
 

--- a/kafka/tools/assigner/actions/remove.py
+++ b/kafka/tools/assigner/actions/remove.py
@@ -16,6 +16,7 @@
 # under the License.
 
 from collections import deque
+from kafka.tools.assigner import log
 from kafka.tools.assigner.actions import ActionModule
 from kafka.tools.assigner.exceptions import ConfigurationException, NotEnoughReplicasException
 
@@ -53,6 +54,10 @@ class ActionRemove(ActionModule):
             for position in broker.partitions:
                 iterlist = list(broker.partitions[position])
                 for partition in iterlist:
+                    if partition.topic.name in self.args.exclude_topics:
+                        log.debug("Skipping partition {0}-{1} due to exclude-topics".format(partition.topic.name, partition.num))
+                        continue
+
                     # Find a new replica for this partition
                     newreplica = None
                     attempts = 0

--- a/kafka/tools/assigner/actions/reorder.py
+++ b/kafka/tools/assigner/actions/reorder.py
@@ -30,7 +30,7 @@ class ActionReorder(ActionModule):
         for broker in self.cluster.brokers:
             leaders[broker] = 0
 
-        for partition in self.cluster.partitions():
+        for partition in self.cluster.partitions(self.args.exclude_topics):
             # The best leader is either:
             #  1) The first replica that has 0 leaders so far
             #  2) The replica with the lowest leader ratio

--- a/kafka/tools/assigner/actions/setrf.py
+++ b/kafka/tools/assigner/actions/setrf.py
@@ -44,7 +44,7 @@ class ActionSetRF(ActionModule):
         random.shuffle(idlist)
         brokers = deque(idlist)
 
-        for partition in self.cluster.partitions():
+        for partition in self.cluster.partitions(self.args.exclude_topics):
             if partition.topic.name not in self.args.topics:
                 continue
 

--- a/kafka/tools/assigner/actions/trim.py
+++ b/kafka/tools/assigner/actions/trim.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from kafka.tools.assigner import log
 from kafka.tools.assigner.actions import ActionModule
 from kafka.tools.assigner.exceptions import NotEnoughReplicasException
 
@@ -41,11 +40,13 @@ class ActionTrim(ActionModule):
             for position in broker.partitions:
                 partition_list = broker.partitions[position][:]
                 for partition in partition_list:
-                    if partition.topic.name in self.args.exclude_topics:
-                        log.debug("Skipping partition {0}-{1} due to exclude-topics".format(partition.topic.name, partition.num))
-                        continue
+                    self._process_partition(broker, partition)
 
-                    partition.remove_replica(broker)
-                    if len(partition.replicas) < 1:
-                        raise NotEnoughReplicasException("Cannot trim {0}:{1} as it would result in an empty replica list".format(
-                            partition.topic.name, partition.num))
+    def _process_partition(self, broker, partition):
+        if partition.topic.name in self.args.exclude_topics:
+            return
+
+        partition.remove_replica(broker)
+        if len(partition.replicas) < 1:
+            raise NotEnoughReplicasException("Cannot trim {0}:{1} as it would result in an empty replica list".format(
+                partition.topic.name, partition.num))

--- a/kafka/tools/assigner/actions/trim.py
+++ b/kafka/tools/assigner/actions/trim.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from kafka.tools.assigner import log
 from kafka.tools.assigner.actions import ActionModule
 from kafka.tools.assigner.exceptions import NotEnoughReplicasException
 
@@ -40,6 +41,10 @@ class ActionTrim(ActionModule):
             for position in broker.partitions:
                 partition_list = broker.partitions[position][:]
                 for partition in partition_list:
+                    if partition.topic.name in self.args.exclude_topics:
+                        log.debug("Skipping partition {0}-{1} due to exclude-topics".format(partition.topic.name, partition.num))
+                        continue
+
                     partition.remove_replica(broker)
                     if len(partition.replicas) < 1:
                         raise NotEnoughReplicasException("Cannot trim {0}:{1} as it would result in an empty replica list".format(

--- a/kafka/tools/assigner/arguments.py
+++ b/kafka/tools/assigner/arguments.py
@@ -19,6 +19,22 @@ import argparse
 import pkg_resources
 
 
+class CSVAction(argparse.Action):
+    def __init__(self, option_strings, dest, nargs=None, **kwargs):
+        if nargs is not None:
+            raise ValueError("nargs not allowed")
+        super(CSVAction, self).__init__(option_strings, dest, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        val_array = values.split(',')
+        if hasattr(namespace, self.dest):
+            old_array = getattr(namespace, self.dest)
+            if old_array is not None:
+                old_array.extend(val_array)
+                val_array = old_array
+        setattr(namespace, self.dest, val_array)
+
+
 # action_map is a map of names to ActionModule children - the top level actions that can be called
 # sizer_map is a map of names to SizerModule children - the modules to get partition sizes
 def set_up_arguments(action_map, sizer_map, plugins):
@@ -31,6 +47,7 @@ def set_up_arguments(action_map, sizer_map, plugins):
     aparser.add_argument('-g', '--generate', help="Generate partition reassignment file", action='store_true')
     aparser.add_argument('-e', '--execute', help="Execute partition reassignment", action='store_true')
     aparser.add_argument('-m', '--moves', help="Max number of moves per step", required=False, default=10, type=int)
+    aparser.add_argument('-x', '--exclude-topics', help="Comma-separated list of topics to skip when performing actions", action=CSVAction, default=[])
     aparser.add_argument('--sizer', help="Select module to use to get partition sizes", required=False, default='ssh', choices=sizer_map.keys())
     aparser.add_argument('-s', '--size', help="Show partition sizes", action='store_true')
     aparser.add_argument('-d', '--datadir', help="Path to the data directory on the broker", required=False, default="/mnt/u001/kafka/i001_caches")

--- a/kafka/tools/assigner/models/cluster.py
+++ b/kafka/tools/assigner/models/cluster.py
@@ -112,8 +112,12 @@ class Cluster(BaseModel):
 
     # Iterate over all the partitions in this cluster
     # Order is undefined
-    def partitions(self):
+    def partitions(self, exclude_topics=[]):
         for topic in self.topics:
+            if topic in exclude_topics:
+                log.debug("Skipping topic {0} due to exclude-topics".format(topic))
+                continue
+
             for partition in self.topics[topic].partitions:
                 yield partition
 
@@ -136,7 +140,7 @@ class Cluster(BaseModel):
     def changed_partitions(self, newcluster):
         moves = []
         try:
-            for partition in newcluster.partitions():
+            for partition in newcluster.partitions([]):
                 if partition.replicas != self.topics[partition.topic.name].partitions[partition.num].replicas:
                     moves.append(partition)
         except KeyError:

--- a/tests/tools/assigner/actions/balancemodules/test_leader.py
+++ b/tests/tools/assigner/actions/balancemodules/test_leader.py
@@ -14,7 +14,7 @@ class ActionBalanceLeaderTests(unittest.TestCase):
     def setUp(self):
         self.cluster = set_up_cluster()
         (self.parser, self.subparsers) = set_up_subparser()
-        self.args = Namespace()
+        self.args = Namespace(exclude_topics=[])
 
     def test_configure_args(self):
         ActionBalance.configure_args(self.subparsers)

--- a/tests/tools/assigner/actions/balancemodules/test_rackaware.py
+++ b/tests/tools/assigner/actions/balancemodules/test_rackaware.py
@@ -22,7 +22,7 @@ class ActionBalanceRackAwareTests(unittest.TestCase):
         self.cluster.topics['testTopic2'].partitions[1].size = 2000
 
         (self.parser, self.subparsers) = set_up_subparser()
-        self.args = Namespace()
+        self.args = Namespace(exclude_topics=[])
 
     def test_configure_args(self):
         ActionBalance.configure_args(self.subparsers)

--- a/tests/tools/assigner/actions/balancemodules/test_size.py
+++ b/tests/tools/assigner/actions/balancemodules/test_size.py
@@ -19,7 +19,7 @@ class ActionBalanceSizeTests(unittest.TestCase):
         self.cluster.topics['testTopic2'].partitions[1].size = 2000
 
         (self.parser, self.subparsers) = set_up_subparser()
-        self.args = Namespace()
+        self.args = Namespace(exclude_topics=[])
 
     def test_configure_args(self):
         ActionBalance.configure_args(self.subparsers)

--- a/tests/tools/assigner/actions/test_balance.py
+++ b/tests/tools/assigner/actions/test_balance.py
@@ -13,7 +13,7 @@ class ActionBalanceTests(unittest.TestCase):
     def setUp(self):
         self.cluster = set_up_cluster()
         (self.parser, self.subparsers) = set_up_subparser()
-        self.args = Namespace()
+        self.args = Namespace(exclude_topics=[])
 
     def test_create_class(self):
         self.args.types = ['count']

--- a/tests/tools/assigner/actions/test_base_class.py
+++ b/tests/tools/assigner/actions/test_base_class.py
@@ -9,7 +9,7 @@ from kafka.tools.assigner.actions import ActionModule, ActionBalanceModule
 class ActionModuleTests(unittest.TestCase):
     def setUp(self):
         self.cluster = set_up_cluster()
-        self.args = Namespace()
+        self.args = Namespace(exclude_topics=[])
 
     def test_create_class(self):
         action = ActionModule(self.args, self.cluster)

--- a/tests/tools/assigner/actions/test_clone.py
+++ b/tests/tools/assigner/actions/test_clone.py
@@ -13,7 +13,7 @@ class ActionCloneTests(unittest.TestCase):
     def setUp(self):
         self.cluster = set_up_cluster()
         (self.parser, self.subparsers) = set_up_subparser()
-        self.args = Namespace()
+        self.args = Namespace(exclude_topics=[])
 
     def test_create_class(self):
         self.args.brokers = [1]

--- a/tests/tools/assigner/actions/test_elect.py
+++ b/tests/tools/assigner/actions/test_elect.py
@@ -11,7 +11,7 @@ class ActionElectTests(unittest.TestCase):
     def setUp(self):
         self.cluster = set_up_cluster()
         (self.parser, self.subparsers) = set_up_subparser()
-        self.args = Namespace()
+        self.args = Namespace(exclude_topics=[])
 
     def test_create_class(self):
         action = ActionElect(self.args, self.cluster)

--- a/tests/tools/assigner/actions/test_remove.py
+++ b/tests/tools/assigner/actions/test_remove.py
@@ -13,7 +13,7 @@ class ActionRemoveTests(unittest.TestCase):
     def setUp(self):
         self.cluster = set_up_cluster()
         (self.parser, self.subparsers) = set_up_subparser()
-        self.args = Namespace()
+        self.args = Namespace(exclude_topics=[])
 
     def test_create_class(self):
         self.args.brokers = [1]
@@ -59,6 +59,22 @@ class ActionRemoveTests(unittest.TestCase):
         b3 = self.cluster.brokers[3]
         assert self.cluster.topics['testTopic1'].partitions[0].replicas == [b3, b2]
         assert self.cluster.topics['testTopic1'].partitions[1].replicas == [b2, b3]
+        assert self.cluster.topics['testTopic2'].partitions[0].replicas == [b2, b3]
+        assert self.cluster.topics['testTopic2'].partitions[1].replicas == [b3, b2]
+
+    def test_process_cluster_exclude(self):
+        self.cluster.add_broker(Broker(3, "brokerhost3.example.com"))
+        self.args.brokers = [1]
+        self.args.to_brokers = []
+        self.args.exclude_topics = ['testTopic1']
+        action = ActionRemove(self.args, self.cluster)
+        action.process_cluster()
+
+        b1 = self.cluster.brokers[1]
+        b2 = self.cluster.brokers[2]
+        b3 = self.cluster.brokers[3]
+        assert self.cluster.topics['testTopic1'].partitions[0].replicas == [b1, b2]
+        assert self.cluster.topics['testTopic1'].partitions[1].replicas == [b2, b1]
         assert self.cluster.topics['testTopic2'].partitions[0].replicas == [b2, b3]
         assert self.cluster.topics['testTopic2'].partitions[1].replicas == [b3, b2]
 

--- a/tests/tools/assigner/actions/test_reorder.py
+++ b/tests/tools/assigner/actions/test_reorder.py
@@ -11,7 +11,7 @@ class ActionReorderTests(unittest.TestCase):
     def setUp(self):
         self.cluster = set_up_cluster()
         (self.parser, self.subparsers) = set_up_subparser()
-        self.args = Namespace()
+        self.args = Namespace(exclude_topics=[])
 
     def test_create_class(self):
         action = ActionReorder(self.args, self.cluster)

--- a/tests/tools/assigner/actions/test_setrf.py
+++ b/tests/tools/assigner/actions/test_setrf.py
@@ -13,7 +13,7 @@ class ActionSetRFTests(unittest.TestCase):
     def setUp(self):
         self.cluster = set_up_cluster()
         (self.parser, self.subparsers) = set_up_subparser()
-        self.args = Namespace()
+        self.args = Namespace(exclude_topics=[])
 
     def test_create_class(self):
         self.args.topics = ['testTopic1']

--- a/tests/tools/assigner/actions/test_trim.py
+++ b/tests/tools/assigner/actions/test_trim.py
@@ -13,7 +13,7 @@ class ActionTrimTests(unittest.TestCase):
     def setUp(self):
         self.cluster = set_up_cluster()
         (self.parser, self.subparsers) = set_up_subparser()
-        self.args = Namespace()
+        self.args = Namespace(exclude_topics=[])
 
     def test_create_class(self):
         self.args.brokers = [1]
@@ -51,6 +51,19 @@ class ActionTrimTests(unittest.TestCase):
         b2 = self.cluster.brokers[2]
         assert self.cluster.topics['testTopic1'].partitions[0].replicas == [b2]
         assert self.cluster.topics['testTopic1'].partitions[1].replicas == [b2]
+        assert self.cluster.topics['testTopic2'].partitions[0].replicas == [b2]
+        assert self.cluster.topics['testTopic2'].partitions[1].replicas == [b2]
+
+    def test_process_cluster_exclude(self):
+        self.args.brokers = [1]
+        self.args.exclude_topics = ['testTopic1']
+        action = ActionTrim(self.args, self.cluster)
+        action.process_cluster()
+
+        b1 = self.cluster.brokers[1]
+        b2 = self.cluster.brokers[2]
+        assert self.cluster.topics['testTopic1'].partitions[0].replicas == [b1, b2]
+        assert self.cluster.topics['testTopic1'].partitions[1].replicas == [b2, b1]
         assert self.cluster.topics['testTopic2'].partitions[0].replicas == [b2]
         assert self.cluster.topics['testTopic2'].partitions[1].replicas == [b2]
 

--- a/tests/tools/assigner/models/test_cluster.py
+++ b/tests/tools/assigner/models/test_cluster.py
@@ -53,9 +53,16 @@ class SimpleClusterTests(unittest.TestCase):
     def test_cluster_partition_iterator(self):
         self.add_topics(2)
         seen_partitions = {}
-        for partition in self.cluster.partitions():
+        for partition in self.cluster.partitions([]):
             seen_partitions["{0}:{1}".format(partition.topic.name, partition.num)] = 1
         assert seen_partitions == {'testTopic1:0': 1, 'testTopic1:1': 1, 'testTopic2:0': 1, 'testTopic2:1': 1}
+
+    def test_cluster_partition_iterator_with_exclude(self):
+        self.add_topics(2)
+        seen_partitions = {}
+        for partition in self.cluster.partitions(['testTopic1']):
+            seen_partitions["{0}:{1}".format(partition.topic.name, partition.num)] = 1
+        assert seen_partitions == {'testTopic2:0': 1, 'testTopic2:1': 1}
 
     def test_cluster_max_replication_factor(self):
         self.add_brokers(2)

--- a/tests/tools/assigner/test_arguments.py
+++ b/tests/tools/assigner/test_arguments.py
@@ -1,3 +1,4 @@
+import argparse
 import inspect
 import sys
 import unittest
@@ -6,7 +7,7 @@ from contextlib import contextmanager
 
 import kafka.tools.assigner.actions
 
-from kafka.tools.assigner.arguments import set_up_arguments
+from kafka.tools.assigner.arguments import set_up_arguments, CSVAction
 from kafka.tools.assigner.modules import get_modules
 from kafka.tools.assigner.plugins import PluginModule
 
@@ -54,3 +55,25 @@ class ArgumentTests(unittest.TestCase):
         assert args.moves == 10
         assert args.ple_size == 2000
         assert args.ple_wait == 120
+
+    def test_csv_action_single(self):
+        aparser = argparse.ArgumentParser()
+        aparser.add_argument('--foo', action=CSVAction)
+        args = aparser.parse_args(['--foo', '1'])
+        assert args.foo == ['1']
+
+    def test_csv_action_nargs(self):
+        aparser = argparse.ArgumentParser()
+        self.assertRaises(ValueError, aparser.add_argument, '--foo', action=CSVAction, nargs='*')
+
+    def test_csv_action_two_args(self):
+        aparser = argparse.ArgumentParser()
+        aparser.add_argument('--foo', action=CSVAction)
+        args = aparser.parse_args(['--foo', '1', '--foo', '2'])
+        assert args.foo == ['1', '2']
+
+    def test_csv_action_commas(self):
+        aparser = argparse.ArgumentParser()
+        aparser.add_argument('--foo', action=CSVAction)
+        args = aparser.parse_args(['--foo', '1,2'])
+        assert args.foo == ['1', '2']

--- a/tests/tools/assigner/test_main.py
+++ b/tests/tools/assigner/test_main.py
@@ -73,6 +73,7 @@ class MainTests(unittest.TestCase):
                                                          datadir='/path/to/data',
                                                          moves=10,
                                                          execute=False,
+                                                         exclude_topics=[],
                                                          generate=False,
                                                          size=False,
                                                          skip_ple=False,

--- a/tests/tools/assigner/test_partition_operations.py
+++ b/tests/tools/assigner/test_partition_operations.py
@@ -127,7 +127,7 @@ class PartitionOperationTests(unittest.TestCase):
             assert newcluster.brokers[bid] == self.cluster.brokers[bid]
         for tname in newcluster.topics:
             assert newcluster.topics[tname] == self.cluster.topics[tname]
-        for partition in newcluster.partitions():
+        for partition in newcluster.partitions([]):
             assert partition == self.cluster.topics[partition.topic.name].partitions[partition.num]
             assert partition.replicas == self.cluster.topics[partition.topic.name].partitions[partition.num].replicas
 


### PR DESCRIPTION
Sometimes you want to skip working on a topic because it's sensitive (like __consumer_offsets). This PR adds an exclude-topics argument that takes a comma-separated list (or multiple arguments). The modules skip over any topics in this list, leaving them alone.