### PR TITLE
Add rate balance module

### DIFF
--- a/kafka/tools/assigner/__main__.py
+++ b/kafka/tools/assigner/__main__.py
@@ -106,7 +106,7 @@ def main():
     tools_path = get_tools_path(args.tools_path)
     check_java_home()
 
-    cluster = Cluster.create_from_zookeeper(args.zookeeper)
+    cluster = Cluster.create_from_zookeeper(args.zookeeper, getattr(args, 'default_retention', 1))
     run_plugins_at_step(plugins, 'set_cluster', cluster)
 
     # If the module needs the partition sizes, call a size module to get the information

--- a/kafka/tools/assigner/actions/balance.py
+++ b/kafka/tools/assigner/actions/balance.py
@@ -41,6 +41,7 @@ class ActionBalance(ActionModule):
         balance_actions = get_modules(kafka.tools.assigner.actions.balancemodules, ActionBalanceModule)
         parser.add_argument('-t', '--types', help="Balance types to perform. Multiple may be specified and they will be run in order", required=True,
                             choices=[klass.name for klass in balance_actions], nargs='*')
+        parser.add_argument('--default-retention', help="Default cluster retention, in ms", required=False, type=int, default=345600000)
 
     def process_cluster(self):
         for bmodule in self.modules:

--- a/kafka/tools/assigner/actions/balancemodules/size.py
+++ b/kafka/tools/assigner/actions/balancemodules/size.py
@@ -25,8 +25,13 @@ class ActionBalanceSize(ActionBalanceModule):
     name = "size"
     helpstr = "Move the largest partitions in the cluster to even the total size on disk per-broker for each replica position"
 
+    # We override this so we can select either the size or the scaled_size attributes to sort on
+    def __init__(self, args, cluster, size_attr='size'):
+        super(ActionBalanceSize, self).__init__(args, cluster)
+        self._size_attr = size_attr
+
     def process_cluster(self):
-        log.info("Starting partition balance by size")
+        log.info("Starting partition balance by {0}".format(self._size_attr))
 
         # Figure out the max RF for the cluster
         max_rf = self.cluster.max_replication_factor()
@@ -43,24 +48,24 @@ class ActionBalanceSize(ActionBalanceModule):
 
             # Create a sorted list of partitions to use at this position (descending size)
             # Throw out partitions that are 4K or less in size, as they are effectively empty
-            partitions[pos] = [p for p in self.cluster.partitions(self.args.exclude_topics) if (len(p.replicas) > pos) and (p.size > 4)]
-            partitions[pos].sort(key=attrgetter('size'), reverse=True)
+            partitions[pos] = [p for p in self.cluster.partitions(self.args.exclude_topics) if (len(p.replicas) > pos) and (getattr(p, self._size_attr) > 4)]
+            partitions[pos].sort(key=attrgetter(self._size_attr), reverse=True)
 
             # Calculate broker size at this position
             for broker in self.cluster.brokers:
                 if pos in self.cluster.brokers[broker].partitions:
-                    sizes[pos][broker] = sum([p.size for p in self.cluster.brokers[broker].partitions[pos]], 0)
+                    sizes[pos][broker] = sum([getattr(p, self._size_attr) for p in self.cluster.brokers[broker].partitions[pos]], 0)
                 else:
                     sizes[pos][broker] = 0
 
             # Calculate the median size of partitions (margin is median/2) and the average size per broker to target
             # Yes, I know the median calculation is slightly broken (it keeps integers). This is OK
-            targets[pos] = sum([p.size for p in partitions[pos]], 0) // len(self.cluster.brokers)
+            targets[pos] = sum([getattr(p, self._size_attr) for p in partitions[pos]], 0) // len(self.cluster.brokers)
             sizelen = len(partitions[pos])
             if not sizelen % 2:
-                margins[pos] = (partitions[pos][sizelen // 2].size + partitions[pos][sizelen // 2 - 1].size) // 4
+                margins[pos] = (getattr(partitions[pos][sizelen // 2], self._size_attr) + getattr(partitions[pos][sizelen // 2 - 1], self._size_attr)) // 4
             else:
-                margins[pos] = partitions[pos][sizelen // 2].size // 2
+                margins[pos] = getattr(partitions[pos][sizelen // 2], self._size_attr) // 2
 
         # Balance partitions for each replica position separately
         for pos in range(max_rf):
@@ -79,11 +84,13 @@ class ActionBalanceSize(ActionBalanceModule):
 
                 # Find partitions to move to this broker
                 for partition in partitions[pos]:
+                    partition_size = getattr(partition, self._size_attr)
+
                     # We can use this partition if all of the following are true: the partition has a replica at this position,
                     # it's size is less than or equal to the max move size, the broker at this replica position would not go out
                     # of range, and it doesn't already exist on this broker at this position
-                    if ((len(partition.replicas) <= pos) or (partition.size > max_move) or
-                       ((sizes[pos][partition.replicas[pos].id] - partition.size) < (targets[pos] - margins[pos])) or
+                    if ((len(partition.replicas) <= pos) or (partition_size > max_move) or
+                       ((sizes[pos][partition.replicas[pos].id] - partition_size) < (targets[pos] - margins[pos])) or
                        (partition.replicas[pos] == broker)):
                         continue
 
@@ -91,22 +98,22 @@ class ActionBalanceSize(ActionBalanceModule):
                     source = partition.replicas[pos]
                     if broker in partition.replicas:
                         other_pos = partition.replicas.index(broker)
-                        if ((sizes[other_pos][broker_id] - partition.size < targets[other_pos] - margins[other_pos]) or
-                           (sizes[other_pos][source.id] + partition.size > targets[pos] + margins[pos]) or
-                           (sizes[pos][broker_id] + partition.size > targets[pos] + margins[pos]) or
-                           (sizes[pos][source.id] - partition.size < targets[pos] - margins[pos])):
+                        if ((sizes[other_pos][broker_id] - partition_size < targets[other_pos] - margins[other_pos]) or
+                           (sizes[other_pos][source.id] + partition_size > targets[pos] + margins[pos]) or
+                           (sizes[pos][broker_id] + partition_size > targets[pos] + margins[pos]) or
+                           (sizes[pos][source.id] - partition_size < targets[pos] - margins[pos])):
                             continue
 
                         partition.swap_replica_positions(source, broker)
-                        sizes[other_pos][broker_id] -= partition.size
-                        sizes[other_pos][source.id] += partition.size
+                        sizes[other_pos][broker_id] -= partition_size
+                        sizes[other_pos][source.id] += partition_size
                     else:
                         # Move the partition and adjust sizes
                         partition.swap_replicas(source, broker)
-                    sizes[pos][broker_id] += partition.size
-                    sizes[pos][source.id] -= partition.size
-                    min_move -= partition.size
-                    max_move -= partition.size
+                    sizes[pos][broker_id] += partition_size
+                    sizes[pos][source.id] -= partition_size
+                    min_move -= partition_size
+                    max_move -= partition_size
 
                     # If we have moved enough partitions, stop for this broker
                     if min_move <= 0:

--- a/kafka/tools/assigner/models/partition.py
+++ b/kafka/tools/assigner/models/partition.py
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from __future__ import division
+
 from kafka.tools.assigner.exceptions import ReplicaNotFoundException
 from kafka.tools.assigner.models import BaseModel
 
@@ -27,6 +29,7 @@ class Partition(BaseModel):
         self.num = num
         self.replicas = []
         self.size = 0
+        self.scaled_size = 0
 
     # Shallow copy - do not copy replica list (zero length)
     def copy(self):
@@ -38,6 +41,7 @@ class Partition(BaseModel):
     def set_size(self, size):
         if size > self.size:
             self.size = size
+            self.scaled_size = (self.topic.cluster.retention / self.topic.retention) * self.size
 
     def dict_for_reassignment(self):
         return {"topic": self.topic.name, "partition": self.num, "replicas": [broker.id for broker in self.replicas]}

--- a/tests/tools/assigner/actions/balancemodules/test_rate.py
+++ b/tests/tools/assigner/actions/balancemodules/test_rate.py
@@ -1,0 +1,44 @@
+import sys
+import unittest
+
+from argparse import Namespace
+from ..fixtures import set_up_cluster, set_up_subparser
+
+from kafka.tools.assigner.actions.balance import ActionBalance
+from kafka.tools.assigner.actions.balancemodules.rate import ActionBalanceRate
+
+
+class ActionBalanceRateTests(unittest.TestCase):
+    def setUp(self):
+        self.cluster = set_up_cluster()
+        self.cluster.topics['testTopic1'].partitions[0].set_size(1000)
+        self.cluster.topics['testTopic1'].partitions[1].set_size(1000)
+        self.cluster.topics['testTopic2'].partitions[0].set_size(2000)
+        self.cluster.topics['testTopic2'].partitions[1].set_size(2000)
+
+        (self.parser, self.subparsers) = set_up_subparser()
+        self.args = Namespace(exclude_topics=[])
+
+    def test_configure_args(self):
+        ActionBalance.configure_args(self.subparsers)
+        sys.argv = ['kafka-assigner', 'balance', '-t', 'rate']
+        parsed_args = self.parser.parse_args()
+        assert parsed_args.action == 'balance'
+
+    def test_create_class(self):
+        action = ActionBalanceRate(self.args, self.cluster)
+        assert isinstance(action, ActionBalanceRate)
+
+    # This is a duplicate of the size test, but we need at least one test to make sure it does work
+    def test_process_cluster_one_move(self):
+        b1 = self.cluster.brokers[1]
+        b2 = self.cluster.brokers[2]
+        self.cluster.topics['testTopic1'].partitions[0].swap_replica_positions(b1, b2)
+
+        action = ActionBalanceRate(self.args, self.cluster)
+        action.process_cluster()
+
+        assert sum([p.scaled_size for p in self.cluster.brokers[1].partitions[0]], 0) == 3000
+        assert sum([p.scaled_size for p in self.cluster.brokers[1].partitions[1]], 0) == 3000
+        assert sum([p.scaled_size for p in self.cluster.brokers[2].partitions[0]], 0) == 3000
+        assert sum([p.scaled_size for p in self.cluster.brokers[2].partitions[1]], 0) == 3000

--- a/tests/tools/assigner/actions/fixtures.py
+++ b/tests/tools/assigner/actions/fixtures.py
@@ -7,6 +7,7 @@ from kafka.tools.assigner.models.topic import Topic
 
 def set_up_cluster():
     cluster = Cluster()
+    cluster.retention = 100000
     cluster.add_broker(Broker(1, "brokerhost1.example.com"))
     cluster.add_broker(Broker(2, "brokerhost2.example.com"))
     cluster.brokers[1].rack = "a"


### PR DESCRIPTION
The rate balance module is a variant on size balance, except that it scales the size used based on the retention of the topic. Topics that are retained longer than the cluster default (now specified on the command line with --default-retention) will be weighted lower, such that if a topic has double the retention of the cluster, its scaled size will be half its actual size on disk. This will more closely approximate data rate balancing, which was the original intention of the size module.

For the interface, this adds a new --default-retention argument for the balance module so that you can set the retention of the cluster in milliseconds. This information is not currently discoverable in a programmatic manner.