### PR TITLE
Add Prometheus sizer module

### DIFF
--- a/kafka/tools/assigner/sizers/prometheus.py
+++ b/kafka/tools/assigner/sizers/prometheus.py
@@ -1,0 +1,125 @@
+import re
+try:
+    from urllib.request import urlopen
+except ImportError:
+    from urllib import urlopen
+
+from kafka.tools import log
+from kafka.tools.exceptions import UnknownBrokerException, ConfigurationException
+from kafka.tools.assigner.sizers import SizerModule
+
+
+class SizerPrometheus(SizerModule):
+    name = 'prometheus'
+    helpstr = 'Get partition sizes by connection to each broker via Prometheus metrics (https://prometheus.io/)'
+
+    def __init__(self, args, cluster):
+        super(SizerPrometheus, self).__init__(args, cluster)
+        self._prom_line_re = re.compile(
+            r'^(?P<name>[a-zA-Z0-9_]+){(?P<labels>[a-zA-Z0-9]+=\".*\")+(?:,+)?(?:\ +)?} (?P<value>[0-9.E]+)$')
+        self._prom_label_re = re.compile(
+            r'^(?P<name>[a-zA-Z0-9]+)=\"(?P<value>.*)\"$')
+
+    def _validate_properties(self):
+        for propname in ['size_metric_name', 'metrics_port']:
+            if propname not in self.properties:
+                raise ConfigurationException(
+                    "Prometheus sizer requires '{}' property to be set".format(
+                        propname))
+
+    def _parse_prometheus_labels(self, label_parts):
+        """
+        Takes list of labels in Prometheus format and turns those into a dict.
+        Example input:
+        ['partition="3"', 'topic="mytopic"']
+        Will return:
+        {
+            'partition: '3',
+            'topic': 'mytopic'
+        }
+
+        :param label_parts: list of label strings
+        :return: dict with parsed labels
+        """
+        labels = {}
+        for label in label_parts:
+            # be sure to strip spaces around the label
+            lm = self._prom_label_re.match(label.strip())
+            if lm and len(lm.groups()) == 2:
+                labels[lm.group('name')] = lm.group('value')
+        return labels
+
+    def _parse_prometheus_value(self, value):
+        try:
+            val = float(value)
+        except ValueError:
+            raise UnknownBrokerException(
+                "Prometheus sizer cannot convert '{}' to float".format(value))
+        return int(val)
+
+    def _parse_prometheus_metric(self, text):
+        """
+        Parse a metric string in Prometheus format, example:
+
+        kafka_log_size{partition="1",topic="mytopic",} 2.759052553E9
+
+        Return dict with name, labels and value, example:
+
+        {
+            'name': 'kafka_log_size',
+            'labels': {'partition': '1', 'topic': 'mytopic'},
+            'value': 2759052553
+        }
+
+        If name, labels or value is missing None will be returned.
+        """
+        metric = {}
+        m = self._prom_line_re.match(text)
+        if m and len(m.groups()) == 3:
+            metric['name'] = m.group('name')
+            metric['value'] = self._parse_prometheus_value(m.group('value'))
+            metric['labels'] = self._parse_prometheus_labels(m.group('labels').split(','))
+
+        return metric or None
+
+    def _get_prometheus_metrics(self, hostname, port, path):
+        url = 'http://{}:{}{}'.format(hostname, port, path)
+        body = ''
+        try:
+            response = urlopen(url)
+            if response.getcode() == 200:
+                body = response.read()
+            else:
+                raise UnknownBrokerException(
+                    "Prometheus sizer received invalid (!=200) response code from {}: {}".format(url, response.getcode()))
+        except Exception as e:
+            raise UnknownBrokerException("Prometheus sizer failed to collect metrics from {}. "
+                                         "Error: {}".format(url, e))
+        return body.splitlines()
+
+    def _query_prometheus(self, hostname):
+        size_metric_name = self.properties['size_metric_name']
+        metrics_port = self.properties['metrics_port']
+        metrics_path = self.properties.get('metrics_path', '/metrics')
+        topic_label = self.properties.get('topic_label', 'topic')
+        partition_label = self.properties.get('partition_label', 'partition')
+        for text in self._get_prometheus_metrics(hostname, metrics_port, metrics_path):
+            m = self._parse_prometheus_metric(text)
+            if m and m['name'] == size_metric_name:
+                topic = m['labels'][topic_label]
+                try:
+                    partition = int(m['labels'][partition_label])
+                except ValueError:
+                    raise UnknownBrokerException(
+                        "Prometheus sizer failed to parse partition '{}' as int".format(m['labels'][partition_label]))
+                self.cluster.topics[topic].partitions[partition].set_size(m['value'])
+
+    def get_partition_sizes(self):
+        self._validate_properties()
+        for broker_id, broker in self.cluster.brokers.items():
+            if broker.hostname is None:
+                raise UnknownBrokerException("Cannot get sizes for broker ID {0} which has no hostname. "
+                                             "Remove the broker from the cluster before balance".format(broker_id))
+
+            log.info("Getting partition sizes via Prometheus exporter for {0}".format(broker.hostname))
+            self._query_prometheus(broker.hostname)

--- a/tests/tools/assigner/sizers/test_prometheus.py
+++ b/tests/tools/assigner/sizers/test_prometheus.py
@@ -1,0 +1,182 @@
+import unittest
+
+from argparse import Namespace
+from mock import patch, Mock
+
+from kafka.tools.exceptions import UnknownBrokerException, ConfigurationException
+from kafka.tools.models.broker import Broker
+from kafka.tools.models.cluster import Cluster
+from kafka.tools.models.topic import Topic
+from kafka.tools.assigner.sizers.prometheus import SizerPrometheus
+
+
+class SizerPrometheusTests(unittest.TestCase):
+    def setUp(self):
+        self.args = Namespace()
+        self.args.property = ['size_metric_name=kafka_log_size', 'metrics_port=1234']
+        self.cluster = self.create_cluster_onehost()
+
+    def create_cluster_onehost(self):
+        cluster = Cluster()
+        cluster.add_broker(Broker("brokerhost1.example.com", id=1))
+        cluster.add_topic(Topic("testTopic1", 2))
+        cluster.add_topic(Topic("testTopic2", 2))
+        partition = cluster.topics['testTopic1'].partitions[0]
+        partition.add_replica(cluster.brokers[1], 0)
+        partition = cluster.topics['testTopic1'].partitions[1]
+        partition.add_replica(cluster.brokers[1], 0)
+        partition = cluster.topics['testTopic2'].partitions[0]
+        partition.add_replica(cluster.brokers[1], 0)
+        partition = cluster.topics['testTopic2'].partitions[1]
+        partition.add_replica(cluster.brokers[1], 0)
+        return cluster
+
+    def test_sizer_create(self):
+        sizer = SizerPrometheus(self.args, self.cluster)
+        assert isinstance(sizer, SizerPrometheus)
+
+    def test_sizer_run_missing_host(self):
+        self.cluster.brokers[1].hostname = None
+        sizer = SizerPrometheus(self.args, self.cluster)
+        self.assertRaises(UnknownBrokerException, sizer.get_partition_sizes)
+
+    def test_sizer_missing_size_metric_name(self):
+        args = Namespace()
+        args.property = ['metrics_port=1234']
+        sizer = SizerPrometheus(args, self.cluster)
+        self.assertRaises(ConfigurationException, sizer.get_partition_sizes)
+
+    def test_sizer_missing_metrics_port(self):
+        args = Namespace()
+        args.property = ['size_metric_name=kafka_log_size']
+        sizer = SizerPrometheus(args, self.cluster)
+        self.assertRaises(ConfigurationException, sizer.get_partition_sizes)
+
+    def test_sizer_parse_prometheus_value_good(self):
+        sizer = SizerPrometheus(self.args, self.cluster)
+        assert sizer._parse_prometheus_value('1234.0') == 1234.0
+        assert sizer._parse_prometheus_value('2.759052553E9') == 2759052553
+
+    def test_sizer_parse_prometheus_value_bad(self):
+        sizer = SizerPrometheus(self.args, self.cluster)
+        self.assertRaises(UnknownBrokerException, sizer._parse_prometheus_value, 'foo')
+        self.assertRaises(UnknownBrokerException, sizer._parse_prometheus_value, '123.0.0')
+        self.assertRaises(UnknownBrokerException, sizer._parse_prometheus_value, 'E')
+
+    def test_sizer_parse_prometheus_metric_good(self):
+        sizer = SizerPrometheus(self.args, self.cluster)
+
+        m = sizer._parse_prometheus_metric(
+            'kafka_log_size{topic="testTopic1", partition="0"} 1234.0')
+        assert m['name'] == 'kafka_log_size'
+        assert m['labels']['topic'] == 'testTopic1'
+        assert m['labels']['partition'] == '0'
+        assert m['value'] == 1234
+
+        m = sizer._parse_prometheus_metric(
+            'kafka_log_size{topic="testTopic1", partition="0",} 1.0')
+        assert m['name'] == 'kafka_log_size'
+        assert m['labels']['topic'] == 'testTopic1'
+        assert m['labels']['partition'] == '0'
+        assert m['value'] == 1
+
+        m = sizer._parse_prometheus_metric(
+            'kafka_log_size{topic="testTopic222", partition="444", } 12.0')
+        assert m['name'] == 'kafka_log_size'
+        assert m['labels']['topic'] == 'testTopic222'
+        assert m['labels']['partition'] == '444'
+        assert m['value'] == 12
+
+        m = sizer._parse_prometheus_metric(
+            'kafka_log_size{topic="mytopic",} 2.759052553E9')
+        self.assertIsInstance(m, dict)
+        assert m['name'] == 'kafka_log_size'
+        assert m['labels']['topic'] == 'mytopic'
+        assert m['value'] == 2759052553
+
+        m = sizer._parse_prometheus_metric(
+            'kafka_log_size{partition="3",topic="mytopic",} 2.759052553E9')
+        self.assertIsInstance(m, dict)
+        assert m['name'] == 'kafka_log_size'
+        assert m['labels']['topic'] == 'mytopic'
+        assert m['labels']['partition'] == '3'
+        assert m['value'] == 2759052553
+
+        m = sizer._parse_prometheus_metric(
+            'kafka_log_size{partition="11",topic="mytopic",extra="foo"} 0.0')
+        self.assertIsInstance(m, dict)
+        assert m['name'] == 'kafka_log_size'
+        assert m['labels']['topic'] == 'mytopic'
+        assert m['labels']['partition'] == '11'
+        assert m['labels']['extra'] == 'foo'
+        assert m['value'] == 0
+
+    def test_sizer_parse_prometheus_metric_bad(self):
+        sizer = SizerPrometheus(self.args, self.cluster)
+
+        m = sizer._parse_prometheus_metric('kafka_log_size 2.0')
+        assert m is None
+
+        m = sizer._parse_prometheus_metric('kafka_log_size{} 0.0')
+        assert m is None
+
+        m = sizer._parse_prometheus_metric('kafka_log_size{topic="abc"} foo')
+        assert m is None
+
+        m = sizer._parse_prometheus_metric('kafka_log_size{topic="abc", partition="1"} foo')
+        assert m is None
+
+    @patch('kafka.tools.assigner.sizers.prometheus.urlopen')
+    def test_sizer_query_prometheus_bad(self, mock_urlopen):
+        m = Mock()
+        m.getcode.return_value = 200
+        m.read.return_value = 'kafka_log_size{topic="foo",partition="abc"} 0.0\n'
+        mock_urlopen.return_value = m
+
+        sizer = SizerPrometheus(self.args, self.cluster)
+        self.assertRaises(UnknownBrokerException, sizer._query_prometheus, 'localhost')
+
+    @patch('kafka.tools.assigner.sizers.prometheus.urlopen')
+    def test_sizer_get_prometheus_metrics_200(self, mock_urlopen):
+        m = Mock()
+        m.getcode.return_value = 200
+        m.read.side_effect = [
+            '# HELP foo\nkafka_log_size{} 1.0\nlog_size{foo="bar"} 1.5\n',
+            '404 not found\n',
+        ]
+        mock_urlopen.return_value = m
+
+        sizer = SizerPrometheus(self.args, self.cluster)
+
+        metrics = sizer._get_prometheus_metrics('localhost', 1234, '/metrics')
+        self.assertSequenceEqual(
+            metrics, [
+                '# HELP foo',
+                'kafka_log_size{} 1.0',
+                'log_size{foo="bar"} 1.5'
+            ])
+
+        metrics = sizer._get_prometheus_metrics('localhost', 1234, '/metrics')
+        self.assertSequenceEqual(metrics, ['404 not found'])
+
+    @patch('kafka.tools.assigner.sizers.prometheus.urlopen')
+    def test_sizer_get_prometheus_metrics_404(self, mock_urlopen):
+        m = Mock()
+        m.getcode.return_value = 404
+        m.read.return_value = '404 not found'
+        mock_urlopen.return_value = m
+
+        sizer = SizerPrometheus(self.args, self.cluster)
+        self.assertRaises(UnknownBrokerException, sizer._get_prometheus_metrics, 'localhost', 1234, '/metrics')
+
+    @patch('kafka.tools.assigner.sizers.prometheus.urlopen')
+    def test_sizer_get_partition_sizes(self, mock_urlopen):
+        m = Mock()
+        m.getcode.return_value = 200
+        m.read.return_value = 'kafka_log_size{topic="testTopic1", partition="0"} 1234.0\n'
+        mock_urlopen.return_value = m
+
+        sizer = SizerPrometheus(self.args, self.cluster)
+        sizer.get_partition_sizes()
+
+        assert self.cluster.topics['testTopic1'].partitions[0].size == 1234


### PR DESCRIPTION
Prometheus sizer can be used with any Prometheus exporter running on each brokers that provides a metric with partition size. It was tested with jmx_exporter.

Required properties:
* -p size_metric_name=kafka_log_Size - size_metric_name provides the name of the metric that should be used, it needs to have labels with both topic name and partition number
* -p metrics_port=9090 - HTTP port on which Prometheus exporter listens on the broker

Optional properties:
* -p metrics_path=/path/to/metrics - URI path for the HTTP request send to each broker, defaults to `/metrics`
* -p topic_label=foo - name of the label containing topic name, defaults to 'topic'
* -p partition_label=bar - name of the label containing partition number, defaults to 'partition'

Example:

`--sizer prometheus -p size_metric_name=kafka_log_size -p metrics_port=9091`

will work with jmx_exporter exposing metrics:

`kafka_log_size{topic="testTopic1", partition="0"} 1234.0`