### PR TITLE
Switch from nose to pytest

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,11 @@
 [bdist_wheel]
 universal=1
 
-[nosetests]
-verbosity=1
-detailed-errors=1
-with-coverage=1
-cover-package=kafka
+[aliases]
+test=pytest
+
+[tool:pytest]
+addopts = --verbose --cov=kafka tests/
 
 [coverage:report]
 exclude_lines =

--- a/setup.py
+++ b/setup.py
@@ -137,16 +137,15 @@ setup(
     tests_require=[
         'coverage',
         'mock',
-        'nose',
-        'nose-capturestderr',
+        'pytest',
+        'pytest-cov',
         'testfixtures',
         'timeout-decorator',
     ],
     setup_requires=[
-        'nose>=1.3.4',
+        'pytest-runner',
         'flake8==3.4.1',
     ],
-    test_suite="nose.collector",
     extras_require={
         'dev': ['check-manifest'],
         'test': ['coverage'],

--- a/setup.py
+++ b/setup.py
@@ -137,8 +137,8 @@ setup(
     tests_require=[
         'coverage',
         'mock',
-        'pytest',
         'pytest-cov',
+        'pytest',
         'testfixtures',
         'timeout-decorator',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ commands =
     check-manifest --ignore tox.ini,tests*
     {py27,py34,py35}: python setup.py check -m -r -s
     flake8 kafka tests
-    python setup.py nosetests --with-coverage
+    python setup.py pytest
 
 [flake8]
 exclude = .tox,*.egg,build,da


### PR DESCRIPTION
Nose hasn't been updated in a couple years. In addition, it is LGPL, which can pose problems for some licensing requirements. Let's switch to pytest, which has everything we need and more.