### PR TITLE
Better handle connection failure

### DIFF
--- a/kafka/tools/client.py
+++ b/kafka/tools/client.py
@@ -504,6 +504,9 @@ class Client:
             requests[broker_id] = request
         return self._send_some_brokers(requests)
 
+    def _make_broker(self, broker_dict):
+        return Broker(broker_dict['host'], id=broker_dict['node_id'], port=broker_dict['port'], configuration=self.configuration)
+
     def _send_group_aware_request(self, group_name, request):
         """
         Sends a request to the broker currently serving as the group coordinator for the specified
@@ -535,7 +538,7 @@ class Client:
         try:
             self.cluster.groups[group_name].coordinator = self.cluster.brokers[response['node_id']]
         except KeyError:
-            broker = Broker(response['host'], id=response['node_id'], port=response['port'], configuration=self.configuration)
+            broker = self._make_broker(response)
             self.cluster.add_broker(broker)
             self.cluster.groups[group_name].coordinator = broker
 
@@ -619,7 +622,7 @@ class Client:
                     broker.hostname = b['host']
                     broker.port = b['port']
             except KeyError:
-                broker = Broker(b['host'], id=b['node_id'], port=b['port'], configuration=self.configuration)
+                broker = self._make_broker(b)
                 self.cluster.add_broker(broker)
             broker.rack = b['rack']
 

--- a/kafka/tools/configuration.py
+++ b/kafka/tools/configuration.py
@@ -200,6 +200,26 @@ class ClientConfiguration(object):
         self._max_request_size = value
 
     @property
+    def num_retries(self):
+        """The number of times to retry a request when there is a failure"""
+        return getattr(self, '_num_retries', 3)
+
+    @num_retries.setter
+    def num_retries(self, value):
+        raise_if_not_positive_integer("_num_retries", value)
+        self._num_retries = value
+
+    @property
+    def retry_backoff(self):
+        """The number of seconds (float) to wait between request retries"""
+        return getattr(self, '_retry_backoff', 0.5)
+
+    @retry_backoff.setter
+    def retry_backoff(self, value):
+        raise_if_not_positive_float("_retry_backoff", value)
+        self._retry_backoff = value
+
+    @property
     def broker_threads(self):
         """How many threads to use in a pool for broker connections"""
         return getattr(self, '_broker_threads', 20)
@@ -261,6 +281,11 @@ class ClientConfiguration(object):
 def raise_if_not_positive_integer(attr_name, value):
     if not (isinstance(value, six.integer_types) and (value > 0)):
         raise TypeError("{0} must be a positive integer".format(attr_name))
+
+
+def raise_if_not_positive_float(attr_name, value):
+    if not (isinstance(value, float) and (value > 0.0)):
+        raise TypeError("{0} must be a positive float".format(attr_name))
 
 
 def raise_if_not_string(attr_name, value):

--- a/tests/tools/client/test_configuration.py
+++ b/tests/tools/client/test_configuration.py
@@ -51,6 +51,18 @@ class ConfigurationTests(unittest.TestCase):
         self.assertRaises(TypeError, ClientConfiguration, max_request_size='foo')
         self.assertRaises(TypeError, ClientConfiguration, max_request_size=-1)
 
+    def test_num_retries(self):
+        config = ClientConfiguration(num_retries=5)
+        assert config.num_retries == 5
+        self.assertRaises(TypeError, ClientConfiguration, num_retries='foo')
+        self.assertRaises(TypeError, ClientConfiguration, num_retries=-1)
+
+    def test_retry_backoff(self):
+        config = ClientConfiguration(retry_backoff=5.4)
+        assert config.retry_backoff == 5.4
+        self.assertRaises(TypeError, ClientConfiguration, retry_backoff='foo')
+        self.assertRaises(TypeError, ClientConfiguration, retry_backoff=-1)
+
     def test_broker_threads(self):
         config = ClientConfiguration(broker_threads=31)
         assert config.broker_threads == 31

--- a/tests/tools/client/test_interface.py
+++ b/tests/tools/client/test_interface.py
@@ -74,7 +74,7 @@ class GenericInterfaceTests(unittest.TestCase):
         self.client._update_from_metadata.side_effect = add_brokers_with_mocks
 
         self.client.connect()
-        mock_connect.assert_has_calls([call(sslcontext=None), call(sslcontext=None)])
+        mock_connect.assert_has_calls([call(), call()])
         mock_send.assert_called_once()
         assert isinstance(mock_send.call_args[0][0], TopicMetadataV1Request)
         mock_close.assert_called_once()

--- a/tests/tools/client/test_send_helpers.py
+++ b/tests/tools/client/test_send_helpers.py
@@ -28,7 +28,7 @@ class SendHelperTests(unittest.TestCase):
 
         assert 'testgroup' in self.client.cluster.groups
         assert self.client.cluster.groups['testgroup'].coordinator == broker1
-        broker1.send.assert_called_once_with('fakerequest', client_id='kafka-tools', request_size=200000)
+        broker1.send.assert_called_once_with('fakerequest')
 
     @patch('kafka.tools.client.Broker')
     def test_send_group_aware_request_new_broker(self, mock_broker_class):
@@ -42,11 +42,11 @@ class SendHelperTests(unittest.TestCase):
         self.client._send_any_broker.return_value = self.group_coordinator
         self.client._send_group_aware_request('testgroup', 'fakerequest')
 
-        mock_broker_class.assert_called_once_with('host1.example.com', id=1, port=8031)
+        mock_broker_class.assert_called_once_with('host1.example.com', id=1, port=8031, configuration=self.client.configuration)
         assert 1 in self.client.cluster.brokers
         assert self.client.cluster.brokers[1] == broker1
         assert self.client.cluster.groups['testgroup'].coordinator == broker1
-        broker1.send.assert_called_once_with('fakerequest', client_id='kafka-tools', request_size=200000)
+        broker1.send.assert_called_once_with('fakerequest')
 
     def test_send_group_aware_request_error(self):
         self.client._send_any_broker = MagicMock()
@@ -66,8 +66,8 @@ class SendHelperTests(unittest.TestCase):
         self.client.cluster.add_broker(broker2)
 
         val = self.client._send_all_brokers('fakerequest')
-        broker1.send.assert_called_once_with('fakerequest', client_id='kafka-tools', request_size=200000)
-        broker2.send.assert_called_once_with('fakerequest', client_id='kafka-tools', request_size=200000)
+        broker1.send.assert_called_once_with('fakerequest')
+        broker2.send.assert_called_once_with('fakerequest')
         assert val[1] == 'fakeresponse'
         assert val[101] == 'otherresponse'
 
@@ -84,8 +84,8 @@ class SendHelperTests(unittest.TestCase):
         self.client.cluster.add_broker(broker2)
 
         val = self.client._send_all_brokers('fakerequest')
-        broker1.send.assert_called_once_with('fakerequest', client_id='kafka-tools', request_size=200000)
-        broker2.send.assert_called_once_with('fakerequest', client_id='kafka-tools', request_size=200000)
+        broker1.send.assert_called_once_with('fakerequest')
+        broker2.send.assert_called_once_with('fakerequest')
         assert val[1] == 'fakeresponse'
         assert val[101] is None
 
@@ -103,7 +103,7 @@ class SendHelperTests(unittest.TestCase):
         self.client.cluster.add_broker(broker2)
 
         val = self.client._send_any_broker('fakerequest')
-        broker2.send.assert_called_once_with('fakerequest', client_id='kafka-tools', request_size=200000)
+        broker2.send.assert_called_once_with('fakerequest')
         assert val == 'otherresponse'
 
     @patch('kafka.tools.client.shuffle', lambda x: sorted(x))
@@ -120,8 +120,8 @@ class SendHelperTests(unittest.TestCase):
         self.client.cluster.add_broker(broker2)
 
         val = self.client._send_any_broker('fakerequest')
-        broker2.send.assert_called_once_with('fakerequest', client_id='kafka-tools', request_size=200000)
-        broker1.send.assert_called_once_with('fakerequest', client_id='kafka-tools', request_size=200000)
+        broker2.send.assert_called_once_with('fakerequest')
+        broker1.send.assert_called_once_with('fakerequest')
         assert val == 'fakeresponse'
 
     @patch('kafka.tools.client.shuffle', lambda x: sorted(x))
@@ -138,8 +138,8 @@ class SendHelperTests(unittest.TestCase):
         self.client.cluster.add_broker(broker2)
 
         self.assertRaises(ConnectionError, self.client._send_any_broker, 'fakerequest')
-        broker1.send.assert_called_once_with('fakerequest', client_id='kafka-tools', request_size=200000)
-        broker2.send.assert_called_once_with('fakerequest', client_id='kafka-tools', request_size=200000)
+        broker1.send.assert_called_once_with('fakerequest')
+        broker2.send.assert_called_once_with('fakerequest')
 
     def test_raise_if_not_connected(self):
         self.assertRaises(ConnectionError, self.client._raise_if_not_connected)


### PR DESCRIPTION
The initial client doesn't handle connection failures at all - if the connection goes away it just raises socket errors or EOFErrors (from ByteBuffer) and there's no clean way to recover. This introduces the concept of retries and a backoff between retries. When there is a failure to send a request or receive a response, the client will close the connection, backoff for the specified amount of time, and retry the request. The client assumes that all failures require reconnecting to the broker, as it's just too difficult to try and determine the state of the connection at that point - a new connection is fast and safe.

I've also refactored a couple things in the client and Broker objects to pass the client configuration to the Broker object earlier. This means we can avoid having to pass every relevant config for every send request.