### PR TITLE
Allow client to work when there's a down broker

### DIFF
--- a/tests/tools/client/test_topics.py
+++ b/tests/tools/client/test_topics.py
@@ -142,6 +142,15 @@ class TopicsTests(unittest.TestCase):
         self.client._update_topics_from_metadata(self.metadata_response)
         assert_cluster_has_topics(self.client.cluster, self.metadata_response)
 
+    def test_update_topics_from_metadata_missing_broker(self):
+        # Don't want to test the broker update code here
+        self.client.cluster.add_broker(Broker('host1.example.com', id=1, port=8031))
+
+        self.client._update_topics_from_metadata(self.metadata_response)
+        assert_cluster_has_topics(self.client.cluster, self.metadata_response)
+        assert 101 in self.client.cluster.brokers
+        assert self.client.cluster.brokers[101].endpoint.hostname is None
+
     def test_maybe_delete_topics_not_in_metadata(self):
         # Don't want to test the broker update code here
         broker1 = Broker('host1.example.com', id=1, port=8031)


### PR DESCRIPTION
This fixes #76 

The way I've handled this is to have the metadata update create the broker entry with a None hostname. The client, when talking to brokers, will skip brokers with a None hostname where it's possible (send to any or send to all).