### PR TITLE
Add support for supplying kafka-reassign-partitions.sh the --throttle argument

### DIFF
--- a/kafka/tools/assigner/__main__.py
+++ b/kafka/tools/assigner/__main__.py
@@ -133,7 +133,7 @@ def main():
 
     for i, batch in enumerate(batches):
         log.info("Executing partition reassignment {0}/{1}: {2}".format(i + 1, len(batches), repr(batch)))
-        batch.execute(i + 1, len(batches), args.zookeeper, tools_path, plugins, dry_run, args.threshold)
+        batch.execute(i + 1, len(batches), args.zookeeper, tools_path, plugins, dry_run, args.throttle)
 
     run_plugins_at_step(plugins, 'before_ple')
 

--- a/kafka/tools/assigner/__main__.py
+++ b/kafka/tools/assigner/__main__.py
@@ -133,7 +133,7 @@ def main():
 
     for i, batch in enumerate(batches):
         log.info("Executing partition reassignment {0}/{1}: {2}".format(i + 1, len(batches), repr(batch)))
-        batch.execute(i + 1, len(batches), args.zookeeper, tools_path, plugins, dry_run)
+        batch.execute(i + 1, len(batches), args.zookeeper, tools_path, plugins, dry_run, args.threshold)
 
     run_plugins_at_step(plugins, 'before_ple')
 

--- a/kafka/tools/assigner/arguments.py
+++ b/kafka/tools/assigner/arguments.py
@@ -47,6 +47,7 @@ def set_up_arguments(action_map, sizer_map, plugins):
     aparser.add_argument('-g', '--generate', help="Generate partition reassignment file", action='store_true')
     aparser.add_argument('-e', '--execute', help="Execute partition reassignment", action='store_true')
     aparser.add_argument('-m', '--moves', help="Max number of moves per step", required=False, default=10, type=int)
+    aparser.add_argument('-r', '--threshold', help="Max B/s per broker to use for reassignment", required=False, default=None, type=long)
     aparser.add_argument('-x', '--exclude-topics', help="Comma-separated list of topics to skip when performing actions", action=CSVAction, default=[])
     aparser.add_argument('--sizer', help="Select module to use to get partition sizes", required=False, default='ssh', choices=sizer_map.keys())
     aparser.add_argument('-p', '--property', help="Property of the form 'key=value' to be passed to modules (i.e. sizer)", required=False, default=[],

--- a/kafka/tools/assigner/arguments.py
+++ b/kafka/tools/assigner/arguments.py
@@ -47,7 +47,7 @@ def set_up_arguments(action_map, sizer_map, plugins):
     aparser.add_argument('-g', '--generate', help="Generate partition reassignment file", action='store_true')
     aparser.add_argument('-e', '--execute', help="Execute partition reassignment", action='store_true')
     aparser.add_argument('-m', '--moves', help="Max number of moves per step", required=False, default=10, type=int)
-    aparser.add_argument('-r', '--throttle', help="Max B/s per broker to use for reassignment", required=False, default=None, type=long)
+    aparser.add_argument('-r', '--throttle', help="Max B/s per broker to use for reassignment", required=False, default=None)
     aparser.add_argument('-x', '--exclude-topics', help="Comma-separated list of topics to skip when performing actions", action=CSVAction, default=[])
     aparser.add_argument('--sizer', help="Select module to use to get partition sizes", required=False, default='ssh', choices=sizer_map.keys())
     aparser.add_argument('-p', '--property', help="Property of the form 'key=value' to be passed to modules (i.e. sizer)", required=False, default=[],

--- a/kafka/tools/assigner/arguments.py
+++ b/kafka/tools/assigner/arguments.py
@@ -47,7 +47,7 @@ def set_up_arguments(action_map, sizer_map, plugins):
     aparser.add_argument('-g', '--generate', help="Generate partition reassignment file", action='store_true')
     aparser.add_argument('-e', '--execute', help="Execute partition reassignment", action='store_true')
     aparser.add_argument('-m', '--moves', help="Max number of moves per step", required=False, default=10, type=int)
-    aparser.add_argument('-r', '--threshold', help="Max B/s per broker to use for reassignment", required=False, default=None, type=long)
+    aparser.add_argument('-r', '--throttle', help="Max B/s per broker to use for reassignment", required=False, default=None, type=long)
     aparser.add_argument('-x', '--exclude-topics', help="Comma-separated list of topics to skip when performing actions", action=CSVAction, default=[])
     aparser.add_argument('--sizer', help="Select module to use to get partition sizes", required=False, default='ssh', choices=sizer_map.keys())
     aparser.add_argument('-p', '--property', help="Property of the form 'key=value' to be passed to modules (i.e. sizer)", required=False, default=[],

--- a/tests/tools/assigner/models/test_reassignment.py
+++ b/tests/tools/assigner/models/test_reassignment.py
@@ -60,7 +60,7 @@ class ReassignmentTests(unittest.TestCase):
         mock_popen.set_default()
         mock_check.side_effect = [10, 5, 0]
 
-        self.reassignment._execute(1, 1, 'zkconnect', '/path/to/tools')
+        self.reassignment._execute(1, 1, 'zkconnect', '/path/to/tools', None)
 
         compare([call.Popen(['/path/to/tools/kafka-reassign-partitions.sh', '--execute', '--zookeeper', 'zkconnect', '--reassignment-json-file', ANY],
                             stderr=ANY, stdout=ANY),

--- a/tests/tools/assigner/models/test_reassignment.py
+++ b/tests/tools/assigner/models/test_reassignment.py
@@ -49,6 +49,11 @@ class ReassignmentTests(unittest.TestCase):
         self.reassignment.execute(1, 1, 'zkconnect', '/path/to/tools', plugins=[self.null_plugin], dry_run=True)
         mock_exec.assert_not_called()
 
+    @patch.object(Reassignment, '_execute')
+    def test_reassignment_execute_threshold(self, mock_exec):
+        self.reassignment.execute(1, 1, 'zkconnect', '/path/to/tools', plugins=[self.null_plugin], dry_run=False, threshold=1000)
+        mock_exec.assert_not_called()
+
     @patch('kafka.tools.assigner.models.reassignment.subprocess.Popen', new_callable=MockPopen)
     @patch.object(Reassignment, 'check_completion')
     def test_reassignment_internal_execute(self, mock_check, mock_popen):

--- a/tests/tools/assigner/models/test_reassignment.py
+++ b/tests/tools/assigner/models/test_reassignment.py
@@ -46,8 +46,8 @@ class ReassignmentTests(unittest.TestCase):
 
     @patch.object(Reassignment, '_execute')
     def test_reassignment_execute_throttle(self, mock_exec):
-        self.reassignment.execute(1, 1, 'zkconnect', '/path/to/tools', plugins=[self.null_plugin], dry_run=False, throttle=1000)
-        mock_exec.assert_called_once_with(1, 1, 'zkconnect', '/path/to/tools', 1000)
+        self.reassignment.execute(1, 1, 'zkconnect', '/path/to/tools', plugins=[self.null_plugin], dry_run=False, throttle='1000')
+        mock_exec.assert_called_once_with(1, 1, 'zkconnect', '/path/to/tools', '1000')
 
     @patch.object(Reassignment, '_execute')
     def test_reassignment_execute_dryrun(self, mock_exec):

--- a/tests/tools/assigner/models/test_reassignment.py
+++ b/tests/tools/assigner/models/test_reassignment.py
@@ -45,8 +45,8 @@ class ReassignmentTests(unittest.TestCase):
         mock_exec.assert_called_once_with(1, 1, 'zkconnect', '/path/to/tools', None)
 
     @patch.object(Reassignment, '_execute')
-    def test_reassignment_execute_threshold(self, mock_exec):
-        self.reassignment.execute(1, 1, 'zkconnect', '/path/to/tools', plugins=[self.null_plugin], dry_run=False, threshold=1000)
+    def test_reassignment_execute_throttle(self, mock_exec):
+        self.reassignment.execute(1, 1, 'zkconnect', '/path/to/tools', plugins=[self.null_plugin], dry_run=False, throttle=1000)
         mock_exec.assert_called_once_with(1, 1, 'zkconnect', '/path/to/tools', 1000)
 
     @patch.object(Reassignment, '_execute')

--- a/tests/tools/assigner/models/test_reassignment.py
+++ b/tests/tools/assigner/models/test_reassignment.py
@@ -42,16 +42,16 @@ class ReassignmentTests(unittest.TestCase):
     @patch.object(Reassignment, '_execute')
     def test_reassignment_execute_real(self, mock_exec):
         self.reassignment.execute(1, 1, 'zkconnect', '/path/to/tools', plugins=[self.null_plugin], dry_run=False)
-        mock_exec.assert_called_once_with(1, 1, 'zkconnect', '/path/to/tools')
-
-    @patch.object(Reassignment, '_execute')
-    def test_reassignment_execute_dryrun(self, mock_exec):
-        self.reassignment.execute(1, 1, 'zkconnect', '/path/to/tools', plugins=[self.null_plugin], dry_run=True)
-        mock_exec.assert_not_called()
+        mock_exec.assert_called_once_with(1, 1, 'zkconnect', '/path/to/tools', None)
 
     @patch.object(Reassignment, '_execute')
     def test_reassignment_execute_threshold(self, mock_exec):
         self.reassignment.execute(1, 1, 'zkconnect', '/path/to/tools', plugins=[self.null_plugin], dry_run=False, threshold=1000)
+        mock_exec.assert_called_once_with(1, 1, 'zkconnect', '/path/to/tools', 1000)
+
+    @patch.object(Reassignment, '_execute')
+    def test_reassignment_execute_dryrun(self, mock_exec):
+        self.reassignment.execute(1, 1, 'zkconnect', '/path/to/tools', plugins=[self.null_plugin], dry_run=True)
         mock_exec.assert_not_called()
 
     @patch('kafka.tools.assigner.models.reassignment.subprocess.Popen', new_callable=MockPopen)

--- a/tests/tools/assigner/test_main.py
+++ b/tests/tools/assigner/test_main.py
@@ -72,6 +72,7 @@ class MainTests(unittest.TestCase):
                                                          tools_path='/path/to/tools',
                                                          property=['datadir=/path/to/data'],
                                                          moves=10,
+                                                         threshold=1000,
                                                          execute=False,
                                                          exclude_topics=[],
                                                          generate=False,

--- a/tests/tools/assigner/test_main.py
+++ b/tests/tools/assigner/test_main.py
@@ -72,7 +72,7 @@ class MainTests(unittest.TestCase):
                                                          tools_path='/path/to/tools',
                                                          property=['datadir=/path/to/data'],
                                                          moves=10,
-                                                         threshold=1000,
+                                                         throttle=1000,
                                                          execute=False,
                                                          exclude_topics=[],
                                                          generate=False,


### PR DESCRIPTION
as of kakfa 10.2 the partition reassignment script can have a bandwidth throttle set.  This provides more predictable control of the load on the cluster than batching alone.