### PR TITLE
Check for zero-length assignment

### DIFF
--- a/kafka/tools/models/group.py
+++ b/kafka/tools/models/group.py
@@ -42,7 +42,7 @@ class Group(BaseModel):
     def add_member(self, name, client_id=None, client_host=None, metadata=None, assignment=None):
         new_member = GroupMember(name, client_id, client_host, metadata, assignment)
         new_member.group = self
-        if (self.protocol_type == 'consumer') and (assignment is not None):
+        if (self.protocol_type == 'consumer') and (assignment is not None) and (len(assignment) > 0):
             new_member.set_assignment()
         self.members.append(new_member)
 

--- a/kafka/tools/protocol/requests/join_group_v0.py
+++ b/kafka/tools/protocol/requests/join_group_v0.py
@@ -30,7 +30,7 @@ def _parse_group_protocol(protocol):
     else:
         try:
             return {'protocol_name': pparts[0], 'protocol_metadata': binascii.unhexlify(pparts[1])}
-        except:
+        except (binascii.Error, TypeError):
             raise ArgumentError("group_protocol_metadata must be empty or a hex string")
 
 

--- a/kafka/tools/protocol/requests/sync_group_v0.py
+++ b/kafka/tools/protocol/requests/sync_group_v0.py
@@ -45,7 +45,7 @@ class SyncGroupV0Request(BaseRequest):
 
         try:
             member_assignments = binascii.unhexlify(cmd_args[3])
-        except:
+        except (binascii.Error, TypeError):
             raise ArgumentError("member_assignments must be a hex string")
 
         try:

--- a/setup.py
+++ b/setup.py
@@ -144,7 +144,7 @@ setup(
     ],
     setup_requires=[
         'pytest-runner',
-        'flake8==3.4.1',
+        'flake8',
     ],
     extras_require={
         'dev': ['check-manifest'],

--- a/tests/tools/models/test_cluster.py
+++ b/tests/tools/models/test_cluster.py
@@ -74,10 +74,10 @@ class SimpleClusterTests(unittest.TestCase):
 
     def test_cluster_log_info(self):
         self.add_brokers(2)
-        with LogCapture() as l:
+        with LogCapture() as line:
             self.cluster.log_broker_summary()
-            l.check(('kafka-tools', 'INFO', 'Broker 1: partitions=0/0 (0.00%), size=0'),
-                    ('kafka-tools', 'INFO', 'Broker 2: partitions=0/0 (0.00%), size=0'))
+            line.check(('kafka-tools', 'INFO', 'Broker 1: partitions=0/0 (0.00%), size=0'),
+                       ('kafka-tools', 'INFO', 'Broker 2: partitions=0/0 (0.00%), size=0'))
 
     def test_cluster_output_json(self):
         self.add_topics(2)

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ basepython =
 deps =
     check-manifest
     {py27,py34,py35}: readme_renderer
-    flake8
+    flake8>=3.5.0
     codeclimate-test-reporter
     coverage
     setuptools>30


### PR DESCRIPTION
If a member in a group has no assignment, the buffer returned will be zero-length (not None). kafka-tools does not check for this case and will throw an EOF error.