### PR TITLE
Fix the ordering of the cluster_id field in metadata responses

### DIFF
--- a/kafka/tools/protocol/responses/metadata_v2.py
+++ b/kafka/tools/protocol/responses/metadata_v2.py
@@ -28,8 +28,8 @@ class MetadataV2Response(MetadataV0Response):
              {'name': 'port', 'type': 'int32'},
              {'name': 'rack', 'type': 'string'},
          ]},
-        {'name': 'controller_id', 'type': 'int32'},
         {'name': 'cluster_id', 'type': 'string'},
+        {'name': 'controller_id', 'type': 'int32'},
         {'name': 'topics',
          'type': 'array',
          'item_type': [

--- a/kafka/tools/protocol/responses/metadata_v3.py
+++ b/kafka/tools/protocol/responses/metadata_v3.py
@@ -29,8 +29,8 @@ class MetadataV3Response(MetadataV0Response):
              {'name': 'port', 'type': 'int32'},
              {'name': 'rack', 'type': 'string'},
          ]},
-        {'name': 'controller_id', 'type': 'int32'},
         {'name': 'cluster_id', 'type': 'string'},
+        {'name': 'controller_id', 'type': 'int32'},
         {'name': 'topics',
          'type': 'array',
          'item_type': [

--- a/kafka/tools/protocol/responses/metadata_v5.py
+++ b/kafka/tools/protocol/responses/metadata_v5.py
@@ -29,8 +29,8 @@ class MetadataV5Response(MetadataV0Response):
              {'name': 'port', 'type': 'int32'},
              {'name': 'rack', 'type': 'string'},
          ]},
-        {'name': 'controller_id', 'type': 'int32'},
         {'name': 'cluster_id', 'type': 'string'},
+        {'name': 'controller_id', 'type': 'int32'},
         {'name': 'topics',
          'type': 'array',
          'item_type': [

--- a/tests/tools/client/test_groups.py
+++ b/tests/tools/client/test_groups.py
@@ -79,7 +79,7 @@ class GroupsTests(unittest.TestCase):
         self.client._send_all_brokers = MagicMock()
         self.client._update_groups_from_lists = MagicMock()
 
-        fake_last_time = time.time() - 1000
+        fake_last_time = time.time() - 1
         self.client._last_group_list = fake_last_time
         self.client._maybe_update_groups_list(cache=False)
 
@@ -89,7 +89,7 @@ class GroupsTests(unittest.TestCase):
         self.client._send_all_brokers = MagicMock()
         self.client._update_groups_from_lists = MagicMock()
 
-        fake_last_time = time.time() - 1000
+        fake_last_time = time.time() - 1
         self.client._last_group_list = fake_last_time
         self.client._maybe_update_groups_list(cache=True)
 

--- a/tests/tools/client/test_topics.py
+++ b/tests/tools/client/test_topics.py
@@ -64,7 +64,7 @@ class TopicsTests(unittest.TestCase):
         self.client._send_any_broker = MagicMock()
         self.client._update_from_metadata = MagicMock()
 
-        fake_last_time = time.time() - 1000
+        fake_last_time = time.time() - 1
         self.client._last_full_metadata = fake_last_time
         self.client._maybe_update_full_metadata(cache=False)
 
@@ -74,7 +74,7 @@ class TopicsTests(unittest.TestCase):
         self.client._send_any_broker = MagicMock()
         self.client._update_from_metadata = MagicMock()
 
-        fake_last_time = time.time() - 1000
+        fake_last_time = time.time() - 1
         self.client._last_full_metadata = fake_last_time
         self.client._maybe_update_full_metadata(cache=True)
 


### PR DESCRIPTION
The ordering of the cluster_id field in new metadata responses was incorrect, leading to decoding errors.