### PR TITLE
Fix list offsets fields

### DIFF
--- a/kafka/tools/models/topic.py
+++ b/kafka/tools/models/topic.py
@@ -92,11 +92,7 @@ class TopicOffsets:
         """
         for partition in partitions:
             raise_if_error(OffsetError, partition['error'])
-            if len(partition['offsets']) > 0:
-                self.partitions[partition['partition']] = partition['offsets'][0]
-            else:
-                # We received no offsets back, so we'll just return -1 to indicate that
-                self.partitions[partition['partition']] = -1
+            self.partitions[partition['partition']] = partition['offset']
 
     def set_offsets_from_fetch(self, partitions):
         """

--- a/kafka/tools/protocol/responses/list_offset_v1.py
+++ b/kafka/tools/protocol/responses/list_offset_v1.py
@@ -29,8 +29,8 @@ class ListOffsetV1Response(BaseResponse):
               'item_type': [
                   {'name': 'partition', 'type': 'int32'},
                   {'name': 'error', 'type': 'int16'},
-                  {'name': 'timestamp', 'type': 'array', 'item_type': 'int64'},
-                  {'name': 'offsets', 'type': 'array', 'item_type': 'int64'},
+                  {'name': 'timestamp', 'type': 'int64'},
+                  {'name': 'offset', 'type': 'int64'},
               ]},
          ]},
     ]

--- a/kafka/tools/protocol/responses/list_offset_v2.py
+++ b/kafka/tools/protocol/responses/list_offset_v2.py
@@ -30,8 +30,8 @@ class ListOffsetV2Response(BaseResponse):
               'item_type': [
                   {'name': 'partition', 'type': 'int32'},
                   {'name': 'error', 'type': 'int16'},
-                  {'name': 'timestamp', 'type': 'array', 'item_type': 'int64'},
-                  {'name': 'offsets', 'type': 'array', 'item_type': 'int64'},
+                  {'name': 'timestamp', 'type': 'int64'},
+                  {'name': 'offset', 'type': 'int64'},
               ]},
          ]},
     ]

--- a/tests/tools/client/fixtures.py
+++ b/tests/tools/client/fixtures.py
@@ -1,5 +1,5 @@
 from kafka.tools.protocol.responses.list_groups_v0 import ListGroupsV0Response
-from kafka.tools.protocol.responses.list_offset_v0 import ListOffsetV0Response
+from kafka.tools.protocol.responses.list_offset_v1 import ListOffsetV1Response
 from kafka.tools.protocol.responses.offset_commit_v2 import OffsetCommitV2Response
 from kafka.tools.protocol.responses.offset_fetch_v1 import OffsetFetchV1Response
 from kafka.tools.protocol.responses.describe_groups_v0 import DescribeGroupsV0Response
@@ -130,33 +130,27 @@ def list_groups_error():
 
 
 def list_offset():
-    return ListOffsetV0Response({'responses': [{'topic': 'topic1',
+    return ListOffsetV1Response({'responses': [{'topic': 'topic1',
                                                 'partition_responses': [{'partition': 0,
                                                                          'error': 0,
-                                                                         'offsets': [4829]},
+                                                                         'offset': 4829,
+                                                                         'timestamp': 1234},
                                                                         {'partition': 1,
                                                                          'error': 0,
-                                                                         'offsets': [8904]}]}]})
-
-
-def list_offset_none():
-    return ListOffsetV0Response({'responses': [{'topic': 'topic1',
-                                                'partition_responses': [{'partition': 0,
-                                                                         'error': 0,
-                                                                         'offsets': [4829]},
-                                                                        {'partition': 1,
-                                                                         'error': 0,
-                                                                         'offsets': []}]}]})
+                                                                         'offset': 8904,
+                                                                         'timestamp': 1234}]}]})
 
 
 def list_offset_error():
-    return ListOffsetV0Response({'responses': [{'topic': 'topic1',
+    return ListOffsetV1Response({'responses': [{'topic': 'topic1',
                                                 'partition_responses': [{'partition': 0,
                                                                          'error': 6,
-                                                                         'offsets': None},
+                                                                         'offset': -1,
+                                                                         'timestamp': -1},
                                                                         {'partition': 1,
                                                                          'error': 0,
-                                                                         'offsets': [8904]}]}]})
+                                                                         'offset': 8904,
+                                                                         'timestamp': 1234}]}]})
 
 
 def offset_fetch():

--- a/tests/tools/models/test_topic_and_partition.py
+++ b/tests/tools/models/test_topic_and_partition.py
@@ -1,6 +1,6 @@
 import unittest
 
-from tests.tools.client.fixtures import list_offset, list_offset_none, list_offset_error, offset_fetch, offset_fetch_error
+from tests.tools.client.fixtures import list_offset, list_offset_error, offset_fetch, offset_fetch_error
 
 from kafka.tools.exceptions import OffsetError
 from kafka.tools.models.cluster import Cluster
@@ -270,15 +270,6 @@ class TopicAndPartitionTests(unittest.TestCase):
         offsets.set_offsets_from_list(response['responses'][0]['partition_responses'])
         assert offsets.partitions[0] == 4829
         assert offsets.partitions[1] == 8904
-
-    def test_set_offsets_empty_from_list(self):
-        topic = Topic('topic1', 2)
-        offsets = TopicOffsets(topic)
-        response = list_offset_none()
-
-        offsets.set_offsets_from_list(response['responses'][0]['partition_responses'])
-        assert offsets.partitions[0] == 4829
-        assert offsets.partitions[1] == -1
 
     def test_set_offsets_from_list_error(self):
         topic = Topic('topic1', 2)


### PR DESCRIPTION
The latest code has a bug in that the response schema for ListOffsets v1 and v2 is not correct, having arrays of timestamps and offsets rather than a single value of each