### PR TITLE
Partition topic must always be a Topic

### DIFF
--- a/kafka/tools/models/topic.py
+++ b/kafka/tools/models/topic.py
@@ -63,7 +63,7 @@ class Topic(BaseModel):
             target_count (int): the number of partitions to have
         """
         while len(self.partitions) < target_count:
-            partition = Partition(self.name, len(self.partitions))
+            partition = Partition(self, len(self.partitions))
             self.add_partition(partition)
 
         # While Kafka doesn't support partition deletion (only topics), it's possible for a topic


### PR DESCRIPTION
There's a critical bug in Topic where Partitions are created (when increasing the partition count) with a string (the topic name) instead of a Topic object