### PR TITLE
more control over assignments execution

### DIFF
--- a/kafka/tools/assigner/__main__.py
+++ b/kafka/tools/assigner/__main__.py
@@ -142,7 +142,7 @@ def main():
     run_plugins_at_step(plugins, 'before_ple')
 
     if not args.skip_ple:
-        all_cluster_partitions = [p for p in action_to_run.cluster.partitions(args.exclude_topics)]
+        all_cluster_partitions = [p for p in action_to_run.cluster.partitions(args.exclude_topics, args.only_topics)]
         batches = split_partitions_into_batches(all_cluster_partitions, batch_size=args.ple_size, use_class=ReplicaElection)
         log.info("Number of replica elections: {0}".format(len(batches)))
         run_preferred_replica_elections(batches, args, tools_path, plugins, dry_run)

--- a/kafka/tools/assigner/__main__.py
+++ b/kafka/tools/assigner/__main__.py
@@ -124,7 +124,7 @@ def main():
     print_leadership("after", newcluster, args.leadership)
 
     move_partitions = cluster.changed_partitions(action_to_run.cluster)
-    batches = split_partitions_into_batches(move_partitions, batch_size=args.moves, use_class=Reassignment)
+    batches = split_partitions_into_batches(move_partitions, batch_size=args.moves, throttle=args.throttle, use_class=Reassignment)
     run_plugins_at_step(plugins, 'set_batches', batches)
 
     log.info("Partition moves required: {0}".format(len(move_partitions)))
@@ -134,6 +134,10 @@ def main():
     for i, batch in enumerate(batches):
         log.info("Executing partition reassignment {0}/{1}: {2}".format(i + 1, len(batches), repr(batch)))
         batch.execute(i + 1, len(batches), args.zookeeper, tools_path, plugins, dry_run)
+
+        if args.move_wait > 0:
+            log.info("Wait {0}s".format(args.move_wait))
+            time.sleep(args.move_wait)
 
     run_plugins_at_step(plugins, 'before_ple')
 

--- a/kafka/tools/assigner/arguments.py
+++ b/kafka/tools/assigner/arguments.py
@@ -48,6 +48,7 @@ def set_up_arguments(action_map, sizer_map, plugins):
     aparser.add_argument('-e', '--execute', help="Execute partition reassignment", action='store_true')
     aparser.add_argument('-m', '--moves', help="Max number of moves per step", required=False, default=10, type=int)
     aparser.add_argument('-x', '--exclude-topics', help="Comma-separated list of topics to skip when performing actions", action=CSVAction, default=[])
+    aparser.add_argument('--only-topics', help="Comma-separated list of topics to limit actions to", action=CSVAction, default=[])
     aparser.add_argument('--sizer', help="Select module to use to get partition sizes", required=False, default='ssh', choices=sizer_map.keys())
     aparser.add_argument('-p', '--property', help="Property of the form 'key=value' to be passed to modules (i.e. sizer)", required=False, default=[],
                          action='append')

--- a/kafka/tools/assigner/arguments.py
+++ b/kafka/tools/assigner/arguments.py
@@ -55,6 +55,8 @@ def set_up_arguments(action_map, sizer_map, plugins):
     aparser.add_argument('--skip-ple', help="Skip preferred replica election after finishing moves", action='store_true')
     aparser.add_argument('--ple-size', help="Max number of partitions in a single preferred leader election", required=False, default=2000, type=int)
     aparser.add_argument('--ple-wait', help="Time in seconds to wait between preferred leader elections", required=False, default=120, type=int)
+    aparser.add_argument('--move-wait', help="Time in seconds to wait between moves", required=False, default=0, type=int)
+    aparser.add_argument('--throttle', help="Throttle in bytes/sec", required=False, default=0, type=int)
     aparser.add_argument('--tools-path', help="Path to Kafka admin utilities, overriding PATH env var", required=False)
     aparser.add_argument('--output-json', help="Output JSON-formatted cluster information to stdout", default=False, action='store_true')
 

--- a/kafka/tools/assigner/batcher.py
+++ b/kafka/tools/assigner/batcher.py
@@ -18,12 +18,12 @@
 from kafka.tools.exceptions import ProgrammingException
 
 
-def split_partitions_into_batches(partitions, batch_size=10, use_class=None):
+def split_partitions_into_batches(partitions, batch_size=10, throttle=0, use_class=None):
     # Currently, this is a very simplistic implementation that just breaks the list of partitions down
     # into even sized chunks. While it could be implemented as a generator, it's not so that it can
     # split the list into more efficient batches.
     if use_class is None:
         raise ProgrammingException("split_partitions_into_batches called with no use_class")
 
-    batches = [use_class(partitions[i:i + batch_size]) for i in range(0, len(partitions), batch_size)]
+    batches = [use_class(partitions[i:i + batch_size], throttle=throttle) for i in range(0, len(partitions), batch_size)]
     return batches

--- a/kafka/tools/assigner/models/replica_election.py
+++ b/kafka/tools/assigner/models/replica_election.py
@@ -26,7 +26,7 @@ from kafka.tools.models import BaseModel
 class ReplicaElection(BaseModel):
     equality_attrs = ['partitions']
 
-    def __init__(self, partitions, pause_time=300):
+    def __init__(self, partitions, pause_time=300, throttle=0):
         self.partitions = partitions
         self.pause_time = pause_time
 

--- a/kafka/tools/models/cluster.py
+++ b/kafka/tools/models/cluster.py
@@ -133,14 +133,22 @@ class Cluster(BaseModel):
 
     # Iterate over all the partitions in this cluster
     # Order is alphabetical by topic, numeric by partition
-    def partitions(self, exclude_topics=[]):
-        for topic in sorted(self.topics):
-            if topic in exclude_topics:
-                log.debug("Skipping topic {0} due to exclude-topics".format(topic))
-                continue
+    def partitions(self, exclude_topics=[], only_topics=[]):
+        if len(only_topics) > 0:
+            for topic in sorted(self.topics):
+                if topic in only_topics:
+                    for partition in self.topics[topic].partitions:
+                        yield partition
 
-            for partition in self.topics[topic].partitions:
-                yield partition
+                log.debug("Skipping topic {0} because it's not in only-topics".format(topic))
+        else:
+            for topic in sorted(self.topics):
+                if topic in exclude_topics:
+                    log.debug("Skipping topic {0} due to exclude-topics".format(topic))
+                    continue
+
+                for partition in self.topics[topic].partitions:
+                    yield partition
 
     def num_brokers(self):
         return len(self.brokers)


### PR DESCRIPTION
Hi,

this PR add two arguments to the assigner script:

-  `--move-wait` which adds a delay between each move execution. Takes the delay in seconds as an int.
-  `--throttle` which adds the `--throttle` argument to the `kafka-reassign-partitions.sh| call. Takes the rate in bytes/sec as an int.

This allow a more controlled rebalancing on clusters which are a little tight in resources.