### PR TITLE
tox now passes HOME as env variable to testenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{27,34,35}
 
 [testenv]
+passenv = HOME
 basepython =
     py27: python2.7
     py34: python3.4


### PR DESCRIPTION
This is just a small change to prep the master branch for PR #91 by plugging trigger to an open potential python bug [1]. I have confirmed this change plugs the potential bug [2]

[1] https://bugs.python.org/issue10496
[2] https://github.com/akashvacher/kafka-tools/commit/2228e65f43ce86b28bae8b32e35ad703d54a18a0