### PR TITLE
 introducing support for sshuser and sshkey in ssh sizer module

### DIFF
--- a/kafka/tools/assigner/sizers/ssh.py
+++ b/kafka/tools/assigner/sizers/ssh.py
@@ -56,7 +56,6 @@ class SizerSSH(SizerModule):
                 proc = subprocess.Popen(['ssh', connection_endpoint, 'du -sk {0}/*'.format(self.properties['datadir'])],
                                         stdout=subprocess.PIPE, stderr=FNULL)
             else:
-                key = self.properties['sshkey']
                 log.info("Getting partition sizes via SSH using key: {0} for {1}".format(key, broker.hostname))
                 proc = subprocess.Popen(['ssh','-i', key, connection_endpoint,
                                          'du -sk {0}/*'.format(self.properties['datadir'])],

--- a/kafka/tools/assigner/sizers/ssh.py
+++ b/kafka/tools/assigner/sizers/ssh.py
@@ -57,7 +57,7 @@ class SizerSSH(SizerModule):
                                         stdout=subprocess.PIPE, stderr=FNULL)
             else:
                 log.info("Getting partition sizes via SSH using key: {0} for {1}".format(key, broker.hostname))
-                proc = subprocess.Popen(['ssh','-i', key, connection_endpoint,
+                proc = subprocess.Popen(['ssh', '-i', key, connection_endpoint,
                                          'du -sk {0}/*'.format(self.properties['datadir'])],
                                         stdout=subprocess.PIPE, stderr=FNULL)
 

--- a/kafka/tools/assigner/sizers/ssh.py
+++ b/kafka/tools/assigner/sizers/ssh.py
@@ -36,7 +36,6 @@ class SizerSSH(SizerModule):
         # Get broker partition sizes
         FNULL = open(os.devnull, 'w')
 
-
         for broker_id, broker in self.cluster.brokers.items():
             if broker.hostname is None:
                 raise UnknownBrokerException("Cannot get sizes for broker ID {0} which has no hostname. "


### PR DESCRIPTION
This PR will make it possible to specify the ssh user and ssh key to be used within the SSH sizer module.
For example:
```
kafka-assigner -z <ZK_IP>:2181 --sizer ssh -p sshkey="my.pem" -p sshuser="ubuntu" balance -t count size rackaware
```
If no properties are specified, default behaviour is applied.