### PR TITLE
Fixes #101 - Show help messages for individual commands

### DIFF
--- a/kafka/tools/protocol/help.py
+++ b/kafka/tools/protocol/help.py
@@ -28,7 +28,7 @@ def show_help(request_classes, request_cmds, cmd_args):
                                             ", ".join([request_classes[request][ver].cmd + "V{0}".format(ver)
                                                        for ver in sorted(request_classes[request].keys())])))
         print("\nFor more information on a request, type \"help <request>\"")
-    elif cmd_args[0] in request_cmds:
-        print(request_cmds[cmd_args[0]].help_string)
+    elif cmd_args[0].lower() in request_cmds:
+        print(request_cmds[cmd_args[0].lower()].help_string)
     else:
         print("{0} is not a valid request".format(cmd_args[0]))


### PR DESCRIPTION
This fixes the issue with help command. Now help <command>
will show the desired help string for valid commands